### PR TITLE
Disable auto-execute in qtconsole

### DIFF
--- a/config/ipython_qtconsole_config.py
+++ b/config/ipython_qtconsole_config.py
@@ -1,1 +1,6 @@
-# Empty.
+c = get_config()
+
+# QtConsole try to guess base on Python lexing when the input is done to auto
+# execute.  This Fails on Haskell, and while it is not possible to do the
+# lexing in the kernel just deactivate functionality
+c.IPythonWidget.execute_on_complete_input = False


### PR DESCRIPTION
Console try to guess base on Python lexing when the input is done to auto
execute.  This Fails on Haskell, and while it is not possible to do the
lexing in the kernel just deactivate functionality.

---

With this in qtconsole you can force  execution or new line with alt-enter/ctrl-enter
