### PR TITLE
add custom.js file for notebook customisation

### DIFF
--- a/IHaskell/Config.hs
+++ b/IHaskell/Config.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE QuasiQuotes #-}
-module IHaskell.Config (ipython, notebook, console, qtconsole) where
+module IHaskell.Config (ipython, notebook, console, qtconsole, customjs) where
 
 import Data.String.Here
 import ClassyPrelude
@@ -15,3 +15,6 @@ console = [template|config/ipython_console_config.py|]
 
 qtconsole :: String
 qtconsole = [template|config/ipython_qtconsole_config.py|]
+
+customjs :: String
+customjs = [template|config/custom.js|]

--- a/IHaskell/IPython.hs
+++ b/IHaskell/IPython.hs
@@ -87,6 +87,7 @@ writeConfigFilesTo profileDir ihaskellPath = do
     writeFile (conf "ipython_notebook_config.py")   Config.notebook
     writeFile (conf "ipython_console_config.py")    Config.console
     writeFile (conf "ipython_qtconsole_config.py")  Config.qtconsole
+    writeFile (conf "static/custom/custom.js")      Config.customjs
   where
     conf filename = fromText $ profileDir ++ filename
 

--- a/config/custom.js
+++ b/config/custom.js
@@ -1,0 +1,83 @@
+// leave at least 2 line with only a star on it below, or doc generation fails
+/**
+ *
+ *
+ * Placeholder for custom user javascript
+ * mainly to be overridden in profile/static/js/custom.js
+ * This will always be an empty file in IPython
+ *
+ * User could add any javascript in the `profile/static/js/custom.js` file
+ * (and should create it if it does not exist).
+ * It will be executed by the ipython notebook at load time.
+ *
+ * Same thing with `profile/static/css/custom.css` to inject custom css into the notebook.
+ *
+ * Example :
+ *
+ * Create a custom button in toolbar that execute `%qtconsole` in kernel
+ * and hence open a qtconsole attached to the same kernel as the current notebook
+ *
+ *    $([IPython.events]).on('notebook_loaded.Notebook', function(){
+ *        IPython.toolbar.add_buttons_group([
+ *            {
+ *                 'label'   : 'run qtconsole',
+ *                 'icon'    : 'ui-icon-calculator', // select your icon from http://jqueryui.com/themeroller/
+ *                 'callback': function(){IPython.notebook.kernel.execute('%qtconsole')}
+ *            }
+ *            // add more button here if needed.
+ *            ]);
+ *    });
+ *
+ * Example :
+ *
+ *  Use `jQuery.getScript(url [, success(script, textStatus, jqXHR)] );`
+ *  to load custom script into the notebook.
+ *
+ *    // to load the metadata ui extension example.
+ *    $.getScript('/static/js/celltoolbarpresets/example.js');
+ *    // or
+ *    // to load the metadata ui extension to control slideshow mode / reveal js for nbconvert
+ *    $.getScript('/static/js/celltoolbarpresets/slideshow.js');
+ *
+ *
+ * @module IPython
+ * @namespace IPython
+ * @class customjs
+ * @static
+ */
+
+// end of IPython unmodified version 
+
+
+$([IPython.events]).on('notebook_loaded.Notebook', function(){
+    // add here logic that should be run once per **notebook load**
+    // (!= page load), like restarting a checkpoint
+
+    var md = IPython.notebook.metadata 
+    if(md.language){
+        console.log('language already defined and is :', md.language);
+    } else {
+        md.language = 'haskell' ;
+        console.log('add metadata hint that language is haskell...');
+    }
+});
+
+
+$([IPython.events]).on('app_initialized.NotebookApp', function(){
+    // add here logic that shoudl be run once per **page load**
+    // like adding specific UI, or changing the default value
+    // of codecell highlight.
+
+    CodeMirror.requireMode('haskell', function(){
+        cells = IPython.notebook.get_cells();
+        for(var i in cells){
+            c = cells[i];
+            if (c.cell_type === 'code'){
+                c.auto_highlight()
+            }
+        }
+    })
+
+    IPython.CodeCell.options_default['cm_config']['mode'] = 'haskell';
+});
+


### PR DESCRIPTION
Highlighting should now be correct in live notebook app. At least on IPython > 1.1.0 and 2.0.0-dev.
Will **not** work but fails gracefully on 1.0.0. (syntax highlight will still by python)

Also this adds a small hint into notebook metadata that notebook is haskell that **might** be use later.
(IRuby and IJulia do the same)

Highlight will not be correct on nbviewer, but there is nothing you can do for now,
at some point I might use above hint to highlight correctly on nbviewer.
