### PR TITLE
select another default random port for notebook

### DIFF
--- a/config/ipython_notebook_config.py
+++ b/config/ipython_notebook_config.py
@@ -1,1 +1,2 @@
-# Empty.
+c = get_config()
+c.NotebookApp.port = 8778


### PR DESCRIPTION
Otherwise browser might do some non-desired caching of some
resources like custom.js which is annoying for people using
ipython-notebook for many languages.
