### PR TITLE
Fix up complete_reply messages (#8).

### DIFF
--- a/IHaskell/Message/Writer.hs
+++ b/IHaskell/Message/Writer.hs
@@ -56,8 +56,9 @@ instance ToJSON Message where
                              "execution_count" .= execCount,
                              "code" .= code
                            ]
-  toJSON (CompleteReply _ m t s) = object [
+  toJSON (CompleteReply _ m mt t s) = object [
                              "matches" .= m,
+                             "matched_text" .= mt,
                              "text" .= t,
                              "status" .= if s then "ok" :: String else "error"
                            ]

--- a/IHaskell/Types.hs
+++ b/IHaskell/Types.hs
@@ -200,6 +200,7 @@ data Message
   | CompleteReply {
      header :: MessageHeader,
      completionMatches :: [ByteString],
+     completionMatchedText :: ByteString,
      completionText :: ByteString,
      completionStatus :: Bool
   }


### PR DESCRIPTION
The reason that aavogt's complete_reply messages were not showing up is because the "Messagin in IPython" documentation is missing a field for the complete_reply messages. There needs to be a "matched_text" field which contains the part of the line on which completions were computed. I have added that field and it seems to work now.

FYI, I figured this out because tab completion on the notebook was raising javascript errors in the browser. For future reference, this could be a useful thing to check if something in the notebook is not working.
