### PR TITLE
Fix hspec

### DIFF
--- a/IHaskell.cabal
+++ b/IHaskell.cabal
@@ -80,6 +80,7 @@ library
                        mtl >= 2.1,
                        transformers,
                        haskeline
+
   exposed-modules: IHaskell.Display
                    IHaskell.Eval.Completion
                    IHaskell.Eval.Evaluate
@@ -192,7 +193,9 @@ Test-Suite hspec
                        text >=0.11,
                        mtl >= 2.1,
                        transformers,
-                       haskeline
+                       haskeline,
+                       HUnit
+
   extensions: DoAndIfThenElse
               OverloadedStrings
               ExtendedDefaultRules

--- a/src/Hspec.hs
+++ b/src/Hspec.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE QuasiQuotes, OverloadedStrings, DoAndIfThenElse, ExtendedDefaultRules #-}
+{-# LANGUAGE QuasiQuotes #-}
 module Main where
 import Prelude
 import GHC
@@ -8,7 +8,9 @@ import Control.Monad
 import Control.Monad.Trans ( MonadIO, liftIO )
 import Data.List
 import System.Directory
-import Shelly (Sh, shelly, cmd, (</>), toTextIgnore, cd, withTmpDir)
+import Shelly (Sh, shelly, cmd, (</>), toTextIgnore, cd, withTmpDir, mkdir_p,
+  touchfile)
+import qualified Shelly as Shelly
 import Filesystem.Path.CurrentOS (encodeString)
 import Data.String.Here
 import Data.String.Utils (strip, replace)
@@ -26,6 +28,7 @@ import Debug.Trace
 
 import Test.Hspec
 import Test.Hspec.HUnit
+import Test.HUnit (assertBool)
 
 doGhc = runGhc (Just libdir)
 
@@ -62,35 +65,47 @@ becomes string expected = do
         expectationFailure $ "Expected result to have " ++ show (length expected)
                              ++ " results. Got " ++ show results
 
-      let isPlain (Display mime _) = mime == PlainText
+      let isPlain (Display PlainText _) = True
+          isPlain _ = False
 
       forM_ (zip results expected) $ \(result, expected) ->
-        case extractPlain result of
-          ""-> expectationFailure $ "No plain-text output in " ++ show result
-          str -> str `shouldBe` expected
+        case find isPlain result of
+          Just (Display PlainText str) -> str `shouldBe` expected
+          Nothing -> expectationFailure $ "No plain-text output in " ++ show result
 
 completes string expected = completionTarget newString cursorloc `shouldBe` expected
-  where (newString, cursorloc) = case elemIndex '!' string of
-          Nothing -> error "Expected cursor written as '!'."
-          Just idx -> (replace "!" "" string, idx)
+  where (newString, cursorloc) = case elemIndex '*' string of
+          Nothing -> error "Expected cursor written as '*'."
+          Just idx -> (replace "*" "" string, idx)
 
-completionHas_ wrap string expected = do
-    (matched, completions) <- doGhc $
-      wrap $ do initCompleter
-                complete newString cursorloc
-    let existsInCompletion = (`elem` completions)
-        unmatched = filter (not . existsInCompletion) expected
-    unmatched `shouldBe` []
-  where (newString, cursorloc) = case elemIndex '!' string of
-          Nothing -> error "Expected cursor written as '!'."
-          Just idx -> (replace "!" "" string, idx)
+completionEvent :: String -> [String] -> Interpreter (String, [String])
+completionEvent string expected =  do
+      complete newString cursorloc
+  where (newString, cursorloc) = case elemIndex '*' string of
+          Nothing -> error "Expected cursor written as '*'."
+          Just idx -> (replace "*" "" string, idx)      
 
-completionHas = completionHas_ id
+completionEventInDirectory :: String -> [String] -> IO (String, [String])
+completionEventInDirectory string expected 
+  = withHsDirectory $ completionEvent string expected
+                          
 
-initCompleter :: GhcMonad m => m ()
+shouldHaveCompletionsInDirectory :: String -> [String] -> IO ()
+shouldHaveCompletionsInDirectory string expected 
+  = do (matched, completions) <- completionEventInDirectory string expected 
+       let existsInCompletion = (`elem` completions)
+           unmatched = filter (not . existsInCompletion) expected
+       expected `shouldBeAmong` completions
+
+completionHas string expected 
+  = do (matched, completions) <- doGhc $ do initCompleter 
+                                            completionEvent string expected 
+       let existsInCompletion = (`elem` completions)
+           unmatched = filter (not . existsInCompletion) expected
+       expected `shouldBeAmong` completions
+
+initCompleter :: Interpreter ()
 initCompleter  = do
-  pwd <- Eval.liftIO getCurrentDirectory
-  --Eval.liftIO $ traceIO $ pwd
   flags <- getSessionDynFlags
   setSessionDynFlags $ flags { hscTarget = HscInterpreted, ghcLink = LinkInMemory }
 
@@ -101,13 +116,32 @@ initCompleter  = do
                                    "import Data.Maybe as Maybe"]
   setContext $ map IIDecl imports
 
-withHsDirectory :: (FilePath -> Sh ()) -> IO ()
-withHsDirectory f = shelly $ withTmpDir $ \dirPath ->
+inDirectory :: [Shelly.FilePath] -- ^ directories relative to temporary directory
+              -> [Shelly.FilePath] -- ^ files relative to temporary directory
+              -> Interpreter a
+              -> IO a
+-- | Run an Interpreter action, but first make a temporary directory 
+--   with some files and folder and cd to it.
+inDirectory dirs files action = shelly $ withTmpDir $ \dirPath ->
       do cd dirPath
-         cmd "mkdir"  $ "" </> "dir"
-         cmd "mkdir"  $ "dir" </> "dir1"
-         cmd "touch" "file1.hs"  "dir/file2.hs" "file1.lhs" "dir/file2.lhs"
-         f $ encodeString dirPath
+         mapM_ mkdir_p   dirs
+         mapM_ touchfile files
+         liftIO $ doGhc $ wrap (encodeString dirPath) action 
+      where noPublish = const $ return ()
+            cdEvent path = Eval.evaluate defaultKernelState (":! cd " ++ path) noPublish
+            wrap :: FilePath -> Interpreter a -> Interpreter a
+            wrap path action = 
+              do initCompleter
+                 pwd <- Eval.liftIO getCurrentDirectory
+                 cdEvent path   -- change to the temporary directory
+                 out <- action  -- run action
+                 cdEvent pwd    -- change back to the original directory
+                 return out
+
+withHsDirectory :: Interpreter a  -> IO a
+withHsDirectory = inDirectory ["" </> "dir", "dir" </> "dir1"]
+                    [""</> "file1.hs", "dir" </> "file2.hs",  
+                     "" </> "file1.lhs", "dir" </> "file2.lhs"]
 
 main :: IO ()
 main = hspec $ do
@@ -118,19 +152,19 @@ main = hspec $ do
 completionTests = do
   describe "Completion" $ do
     it "correctly gets the completion identifier without dots" $ do
-       "hello!"              `completes` ["hello"]
-       "hello aa!bb goodbye" `completes` ["aa"]
-       "hello aabb! goodbye" `completes` ["aabb"]
-       "aacc! goodbye"       `completes` ["aacc"]
-       "hello !aabb goodbye" `completes` []
-       "!aabb goodbye"       `completes` []
+       "hello*"              `completes` ["hello"]
+       "hello aa*bb goodbye" `completes` ["aa"]
+       "hello aabb* goodbye" `completes` ["aabb"]
+       "aacc* goodbye"       `completes` ["aacc"]
+       "hello *aabb goodbye" `completes` []
+       "*aabb goodbye"       `completes` []
 
     it "correctly gets the completion identifier with dots" $ do
-       "hello test.aa!bb goodbye" `completes` ["test", "aa"]
-       "Test.!"                   `completes` ["Test", ""]
-       "Test.Thing!"              `completes` ["Test", "Thing"]
-       "Test.Thing.!"             `completes` ["Test", "Thing", ""]
-       "Test.Thing.!nope"         `completes` ["Test", "Thing", ""]
+       "hello test.aa*bb goodbye" `completes` ["test", "aa"]
+       "Test.*"                   `completes` ["Test", ""]
+       "Test.Thing*"              `completes` ["Test", "Thing"]
+       "Test.Thing.*"             `completes` ["Test", "Thing", ""]
+       "Test.Thing.*nope"         `completes` ["Test", "Thing", ""]
 
     it "correctly gets the completion type" $ do
       completionType "import Data." 12 ["Data", ""]      `shouldBe` ModuleName "Data" ""
@@ -142,48 +176,49 @@ completionTests = do
       completionType "a.x" 3 ["a", "x"]                 `shouldBe` Identifier "x"
       completionType "pri" 3 ["pri"]                    `shouldBe` Identifier "pri"
       completionType ":load A" 7 ["A"]                   `shouldBe` HsFilePath ":load A"
+      completionType ":! cd " 6 [""]                     `shouldBe` FilePath   ":! cd "
+
 
     it "properly completes identifiers" $ do
-       "pri!"           `completionHas` ["print"]
-       "ma!"            `completionHas` ["map"]
-       "hello ma!"      `completionHas` ["map"]
-       "print $ catMa!" `completionHas` ["catMaybes"]
+       "pri*"           `completionHas` ["print"]
+       "ma*"            `completionHas` ["map"]
+       "hello ma*"      `completionHas` ["map"]
+       "print $ catMa*" `completionHas` ["catMaybes"]
 
     it "properly completes qualified identifiers" $ do
-       "Control.Monad.liftM!"    `completionHas` [ "Control.Monad.liftM"
+       "Control.Monad.liftM*"    `completionHas` [ "Control.Monad.liftM"
                                                  , "Control.Monad.liftM2"
                                                  , "Control.Monad.liftM5"]
-       "print $ List.intercal!"  `completionHas` ["List.intercalate"]
-       "print $ Data.Maybe.cat!" `completionHas` ["Data.Maybe.catMaybes"]
-       "print $ Maybe.catM!"     `completionHas` ["Maybe.catMaybes"]
+       "print $ List.intercal*"  `completionHas` ["List.intercalate"]
+       "print $ Data.Maybe.cat*" `completionHas` ["Data.Maybe.catMaybes"]
+       "print $ Maybe.catM*"     `completionHas` ["Maybe.catMaybes"]
 
     it "properly completes imports" $ do
-      "import Data.!"  `completionHas` ["Data.Maybe", "Data.List"]
-      "import Data.M!" `completionHas` ["Data.Maybe"]
-      "import Prel!"   `completionHas` ["Prelude"]
+      "import Data.*"  `completionHas` ["Data.Maybe", "Data.List"]
+      "import Data.M*" `completionHas` ["Data.Maybe"]
+      "import Prel*"   `completionHas` ["Prelude"]
 
     it "properly completes haskell file paths on :load directive" $
-       withHsDirectory $ \dirPath ->
          let loading xs = ":load " ++ encodeString xs
              paths xs = map encodeString xs
-             completionHas' = completionHas_ fun
-             publishNothing = const $ return ()
-             fun action = do pwd <- Eval.liftIO getCurrentDirectory
-                             Eval.evaluate defaultKernelState
-                                             (":! cd " ++ dirPath)
-                                             publishNothing
-                             out <- action
-                             Eval.evaluate defaultKernelState
-                                             (":! cd " ++ pwd)
-                                             publishNothing
-                             return out
-         in liftIO $ do
-            loading ("dir" </> "file!") `completionHas'` paths ["dir" </> "file2.hs",
-                                                            "dir" </> "file2.lhs"]
-            loading ("" </> "file1!") `completionHas'` paths ["" </> "file1.hs",
-                                                              "" </> "file1.lhs"]
-            loading ("" </> "file1!") `completionHas'` paths ["" </> "file1.hs",
-                                                  "" </> "file1.lhs"]
+         in do 
+            loading ("dir" </> "file*") `shouldHaveCompletionsInDirectory` paths ["dir" </> "file2.hs",
+                                                                                  "dir" </> "file2.lhs"]
+            loading ("" </> "file1*") `shouldHaveCompletionsInDirectory` paths ["" </> "file1.hs",
+                                                                                            "" </> "file1.lhs"]
+            loading ("" </> "file1*") `shouldHaveCompletionsInDirectory` paths ["" </> "file1.hs",
+                                                                                "" </> "file1.lhs"]
+            loading ("" </> "./*") `shouldHaveCompletionsInDirectory` paths ["./" </> "dir/"
+                                                                                       , "./" </> "file1.hs"
+                                                                                       , "./" </> "file1.lhs"]
+            loading ("" </> "./*") `shouldHaveCompletionsInDirectory` paths ["./" </> "dir/"
+                                                                           , "./" </> "file1.hs"
+                                                                           , "./" </> "file1.lhs"]
+
+    it "provides path completions on empty shell cmds " $ do 
+      ":! cd *" `shouldHaveCompletionsInDirectory` (map encodeString ["" </> "dir/"
+                                                                      , "" </> "file1.hs"
+                                                                      , "" </> "file1.lhs"])
 
 evalTests = do
   describe "Code Evaluation" $ do
@@ -440,3 +475,16 @@ parseStringTests = describe "Parser" $ do
         second
        |] >>= (`shouldBe` [Located 2 (Expression "first"),
                           Located 4 (Expression "second")])
+
+
+-- Useful HSpec expectations ----
+---------------------------------
+
+shouldBeAmong :: (Show a, Eq a) => [a] -> [a] -> Expectation
+-- |
+-- @sublist \`shouldbeAmong\` list@ sets the expectation that @sublist@ elements are 
+-- among those in @list@.
+sublist `shouldBeAmong` list = assertBool errorMsg 
+              $ and [x `elem` list | x <- sublist]
+  where
+    errorMsg = show list ++ " doesn't contain " ++ show sublist


### PR DESCRIPTION
Addresses #112. Hspec.hs compiles and runs now. 4 Code Evaluation tests fail and the :load directive test also fails. 
