### PR TITLE
Remove redundant MarkupSafe download

### DIFF
--- a/src/IHaskell/IPython.hs
+++ b/src/IHaskell/IPython.hs
@@ -176,11 +176,13 @@ installPipDependencies = withTmpDir $ \tmpDir ->
       [
         ("pyzmq", "14.0.1")
       , ("tornado","3.1.1")
-      , ("jinja2","2.7.1")
+      , ("Jinja2","2.7.1")
       -- The following cannot go first in the dependency list, because
       -- their setup.py are broken and require the directory to exist
       -- already.
-      , ("MarkupSafe", "0.18")
+      
+      -- Jinja downloads MarkupSafe, so downloading again causes an error when the tarball exists
+      --, ("MarkupSafe", "0.18")
       --, ("setuptools", "2.0.2")
       ]
   where


### PR DESCRIPTION
Jinja2 seems to download MarkupSafe as well as Jinja2-2.7.1. Having MarkupSafe in the dependency list causes it to fail when the MarkupSafe file already exists.

Also, jinja2 should be Jinja2 as the tarball is Jinja2-2.7.1.tar.gz, not jinja2-2.7.1.tar.gz
