### PR TITLE
fix pip install errors

### DIFF
--- a/src/IHaskell/IPython.hs
+++ b/src/IHaskell/IPython.hs
@@ -175,12 +175,12 @@ installPipDependencies = withTmpDir $ \tmpDir ->
     mapM_ (installDependency tmpDir) 
       [
         ("pyzmq", "14.0.1")
-      , ("tornado","3.1.1")
-      , ("jinja2","2.7.1")
+      , ("tornado", "3.1.1")
+      , ("Jinja2", "2.7.1")
       -- The following cannot go first in the dependency list, because
       -- their setup.py are broken and require the directory to exist
       -- already.
-      , ("MarkupSafe", "0.18")
+      --, ("MarkupSafe", "0.18")
       --, ("setuptools", "2.0.2")
       ]
   where


### PR DESCRIPTION
This patch fixes the following errors when running `IHaskell console`:
- Jinja2 tarball, markupsafe not found
  
  ```
  ... ...
  Downloading/unpacking jinja2==2.7.1
    Real name of requirement jinja2 is Jinja2
  Saved /tmp/tmpThreadId12994/Jinja2-2.7.1.tar.gz
  ... ...
  Successfully downloaded jinja2 markupsafe
  Cleaning up...
  tar (child): jinja2-2.7.1.tar.gz: Cannot open: No such file or directory
  tar (child): Error is not recoverable: exiting now
  /bin/tar: Child returned status 2
  /bin/tar: Error is not recoverable: exiting now
  ... ...
  Couldn't find index page for 'markupsafe' (maybe misspelled?)
  Download error on http://pypi.python.org/simple/: timed out -- Some packages may not be found!
  No local packages or download links found for markupsafe
  error: Could not find suitable distribution for Requirement.parse('markupsafe')
  ```
- MarkupSafe already installed as a dependency of Jinja2
  
  ```
  Searching for markupsafe
  Reading http://pypi.python.org/simple/markupsafe/
  Best match: MarkupSafe 0.18
  Downloading https://pypi.python.org/packages/source/M/MarkupSafe/MarkupSafe-0.18.tar.gz#md5=f8d252fd05371e51dec2fe9a36890687
  Processing MarkupSafe-0.18.tar.gz
  Running MarkupSafe-0.18/setup.py -q bdist_egg --dist-dir /tmp/easy_install-3rw7g1/MarkupSafe-0.18/egg-dist-tmp-XTNM3D
  Adding MarkupSafe 0.18 to easy-install.pth file
  
  Installed /admin/.ihaskell/ipython/lib/python2.7/site-packages/MarkupSafe-0.18-py2.7-linux-x86_64.egg
  Finished processing dependencies for Jinja2==2.7.1
  Installing dependency: MarkupSafe-0.18
  Downloading/unpacking MarkupSafe==0.18
    Downloading MarkupSafe-0.18.tar.gz
  The file /tmp/tmpThreadId16407/MarkupSafe-0.18.tar.gz exists. (i)gnore, (w)ipe, (b)ackup Exception:
  Traceback (most recent call last):
    File "/usr/lib/python2.7/dist-packages/pip/basecommand.py", line 104, in main
  ```
