### PR TITLE
Use virtualenv and requirements.txt to download python's dependencies

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -34,5 +34,7 @@ done
 cd ..
 # Install python's dependencies
 bash ihaskell_python_updater.sh
-cp ihaskell_python_updater.sh ~/.ihaskell/
+bash ipython_updater.sh
+cp python_updater.sh ~/.ihaskell/
+cp ipython_updater.sh ~/.ihaskell/
 cp requirements.txt ~/.ihaskell/

--- a/ipython_updater.sh
+++ b/ipython_updater.sh
@@ -1,0 +1,4 @@
+#! /bin/bash
+source ~/.ihaskell/ipython/bin/activate
+pip install --install-option="--prefix=~/.ihaskell/ipython" -e git+https://github.com/ipython/ipython.git@ae1f2befd1372f37562420aab9d87a0a625ba58d#egg=ipython-dev
+deactivate

--- a/python_updater.sh
+++ b/python_updater.sh
@@ -1,3 +1,5 @@
+#! /bin/bash
+
 # Install python's dependencies in a virtualenv
 mkdir --parents ~/.ihaskell/ipython/
 virtualenv ~/.ihaskell/ipython

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ jinja2==2.7.1
 pyzmq==14.0.1
 tornado==3.1.1
 markupsafe==0.18
-#-e git+https://github.com/ipython/ipython.git@ae1f2befd1372f37562420aab9d87a0a625ba58d#egg=ipython-dev

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -53,11 +53,11 @@ ihaskell (Args (ShowHelp help) _) =
 -- isn't updated. This is hard to detect since versions of IPython might
 -- not change!
 ihaskell (Args UpdateIPython _) = do
-  setupIPython
+  --updateIPython
   putStrLn "IPython updated."
     
 ihaskell (Args Console flags) = showingHelp Console flags $ do
-  setupIPython
+  --setupIPython
 
   flags <- addDefaultConfFile flags
   info <- initInfo IPythonConsole flags
@@ -67,7 +67,7 @@ ihaskell (Args (View (Just fmt) (Just name)) []) =
   nbconvert fmt name
 
 ihaskell (Args Notebook flags) = showingHelp Notebook flags $ do
-  setupIPython
+  --setupIPython
 
   let server = case mapMaybe serveDir flags of
                  [] -> Nothing


### PR DESCRIPTION
As there's been some problems with different systems and python's dependencies (unable to install on certain machines, modifying the users base python install), I think it would be a good idea to move the dependency handling to shells scripts, rather than compiled Haskell. Also, using a virtualenv will make IHaskell's dependencies to not modify the user's python install.
