### PR TITLE
Update virtualenv to 1.10.1

### DIFF
--- a/installation/virtualenv.sh
+++ b/installation/virtualenv.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Which version of virtualenv to use.
-VIRTUALENV=virtualenv-1.9
+VIRTUALENV=virtualenv-1.10.1
 
 # Where to install the virtualenv.
 DESTINATION=$1


### PR DESCRIPTION
This is to include pip-1.4.1 by default. This may break calling `virtualenv.py` as virtualenv-1.10 and newer [may not](https://pypi.python.org/pypi/virtualenv) support it.

Potential fix for gibiansky/IHaskell#160
