### PR TITLE
ipython is stored in bin in the virtualenv

### DIFF
--- a/installation/update.sh
+++ b/installation/update.sh
@@ -8,7 +8,7 @@ VIRTUALENV=$1
 COMMIT=$2
 
 # Find out current IPython commit hash.
-cd $VIRTUALENV/src/ipython
+cd $VIRTUALENV/bin/ipython
 CURRENT_COMMIT=`git rev-parse HEAD`
 if [ $CURRENT_COMMIT != $COMMIT ]; then
   # Activate the virtualenv.


### PR DESCRIPTION
```
$ IHaskell notebook
/Users/kms/.cabal/share/x86_64-osx-ghc-7.6.3/ihaskell-0.3.0.2/installation/update.sh: line 11: cd: /Users/kms/.ihaskell/ipython/src/ipython: No such file or directory
IHaskell: 
Ran commands: 
withTmpDir
rm -f /var/folders/0w/lvfzt96n7dz9_6bnzwf_1x3w0000gn/T/tmpThreadId13035
mkdir /var/folders/0w/lvfzt96n7dz9_6bnzwf_1x3w0000gn/T/tmpThreadId13035
cd /private/var/folders/0w/lvfzt96n7dz9_6bnzwf_1x3w0000gn/T/tmpThreadId13035
bash /Users/kms/.cabal/share/x86_64-osx-ghc-7.6.3/ihaskell-0.3.0.2/installation/update.sh /Users/kms/.ihaskell/ipython dea60d42cf67e2713ad296f79f6962be0a4d7cd3
which bash
rm -rf /var/folders/0w/lvfzt96n7dz9_6bnzwf_1x3w0000gn/T/tmpThreadId13035

Exception: error running: bash /Users/kms/.cabal/share/x86_64-osx-ghc-7.6.3/ihaskell-0.3.0.2/installation/update.sh /Users/kms/.ihaskell/ipython dea60d42cf67e2713ad296f79f6962be0a4d7cd3
exit status: 1
stderr: /Users/kms/.cabal/share/x86_64-osx-ghc-7.6.3/ihaskell-0.3.0.2/installation/update.sh: line 11: cd: /Users/kms/.ihaskell/ipython/src/ipython: No such file or directory
```
