### PR TITLE
add input code re-broadcast

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -301,8 +301,11 @@ replyTo interface req@ExecuteRequest{ getCode = code } replyHeader state = do
           unless (null pager) $
             modifyMVar_ pagerOutput (return . (++ pager ++ "\n"))
 
-  -- Run code and publish to the frontend as we go.
   let execCount = getExecutionCounter state
+  -- Let all frontends know the execution count and code that's about to run
+  inputHeader <- liftIO $ dupHeader replyHeader InputMessage
+  send $ PublishInput inputHeader (Chars.unpack code) execCount
+  -- Run code and publish to the frontend as we go.
   updatedState <- evaluate state (Chars.unpack code) publish
 
   -- Notify the frontend that we're done computing.


### PR DESCRIPTION
Our (ipython) docs probably weren't very clear about this, but frontends 
expect to get a re-broadcast of the input code, along with an execution count
(since otherwise only the frontend which sent an execute_request knows what
was actually executed). I was working on ivanov/vim-ipython#86 and found that
I wasn't getting the In [ ] prompts when connected to an IHaskell kernel.

This is my first non-trivial (though still somewhat trivial) Haskell patch.
