### PR TITLE
cabal install ihaskell.cabal fails

### DIFF
--- a/ihaskell.cabal
+++ b/ihaskell.cabal
@@ -37,7 +37,7 @@ maintainer:          andrew.gibiansky@gmail.com
 
 category:            Development
 
-build-type:          Simple
+build-type:          Custom
 
 -- Constraint on the version of Cabal needed to build this package.
 cabal-version:       >=1.16


### PR DESCRIPTION
The command

```
cabal install ihaskell.cabal
```

fails.

Here is the end of the build log:

```
[14 of 15] Compiling IHaskell.Eval.Completion ( src/IHaskell/Eval/Completion.hs, dist/build/IHaskell/IHaskell-tmp/IHaskell/Eval/Completion.o )
[15 of 15] Compiling Main             ( src/Main.hs, dist/build/IHaskell/IHaskell-tmp/Main.o )
Linking dist/build/IHaskell/IHaskell 
cabal: profile/profile.tar: does not exist
Failed to install ihaskell-0.3.0.4
cabal: Error: some packages failed to install:
ihaskell-0.3.0.4 failed during the final install step. The exception was:
ExitFailure 1
```

Changing the build type from _Simple_ to _Custom_ solves the problem.
