### PR TITLE
A single commit for a couple changes:

### DIFF
--- a/ihaskell-display/ihaskell-charts/IHaskell/Display/Charts.hs
+++ b/ihaskell-display/ihaskell-charts/IHaskell/Display/Charts.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 module IHaskell.Display.Charts () where
 
@@ -11,6 +12,7 @@ import qualified Data.ByteString.Char8 as Char
 import System.IO.Unsafe
 
 import IHaskell.Display
+import IPython.Types
 
 width :: Width
 width = 450
@@ -43,4 +45,6 @@ chartData renderable format = do
   imgData <- readFile $ fpFromString filename
   return $ case format of
     PNG -> png width height $ base64 imgData
-    SVG -> svg $ Char.unpack imgData
+    SVG -> DisplayData MimeHtml $ makeSvgImg $ base64 imgData
+  where
+    makeSvgImg base64data = "<img src=\"data:image/svg+xml;base64," ++ base64data ++ "\"/>"

--- a/ihaskell-display/ihaskell-charts/ihaskell-charts.cabal
+++ b/ihaskell-display/ihaskell-charts/ihaskell-charts.cabal
@@ -65,6 +65,7 @@ library
                        directory,
                        Chart,
                        Chart-cairo,
+                       ipython-kernel,
                        ihaskell >= 0.3
   
   -- Directories containing source files.

--- a/ihaskell-display/ihaskell-diagrams/ihaskell-diagrams.cabal
+++ b/ihaskell-display/ihaskell-diagrams/ihaskell-diagrams.cabal
@@ -62,7 +62,7 @@ library
                        classy-prelude >=0.6,
                        bytestring,
                        directory,
-                       diagrams,
+                       diagrams-core,
                        diagrams-lib, 
                        diagrams-cairo,
                        ihaskell >= 0.3

--- a/ihaskell-display/ihaskell-magic/IHaskell/Display/Magic.hs
+++ b/ihaskell-display/ihaskell-magic/IHaskell/Display/Magic.hs
@@ -14,6 +14,7 @@ import Data.Char
 
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
+import IPython.Types (MimeType(MimeSvg))
 import Data.ByteString.UTF8
 
 instance IHaskellDisplay T.Text where
@@ -30,9 +31,9 @@ b64 :: B.ByteString -> String
 b64 = Char.unpack . Base64.encode
 
 withClass :: MagicClass -> B.ByteString -> DisplayData
-withClass SVG = svg . B.toString
-withClass (PNG w h) = png w h . Base64.encode
-withClass JPG = jpg 400 300 . Base64.encode
+withClass SVG = DisplayData MimeSvg . T.decodeUtf8
+withClass (PNG w h) = png w h . T.decodeUtf8 . Base64.encode
+withClass JPG = jpg 400 300 . T.decodeUtf8 . Base64.encode
 withClass HTML = html . B.toString 
 withClass LaTeX = latex . B.toString
 withClass _ = plain . B.toString

--- a/ihaskell-display/ihaskell-magic/ihaskell-magic.cabal
+++ b/ihaskell-display/ihaskell-magic/ihaskell-magic.cabal
@@ -68,6 +68,7 @@ library
                        bytestring,
                        utf8-string,
                        base64-bytestring,
+                       ipython-kernel,
                        ihaskell >= 0.3
   
   -- Directories containing source files.

--- a/ihaskell-display/ihaskell-rlangqq/IHaskell/Display/Rlangqq.hs
+++ b/ihaskell-display/ihaskell-rlangqq/IHaskell/Display/Rlangqq.hs
@@ -1,0 +1,108 @@
+{-# OPTIONS_GHC -fno-warn-missing-fields #-}
+{-# LANGUAGE TupleSections, TemplateHaskell #-}
+module IHaskell.Display.Rlangqq
+  ( module RlangQQ,
+    rDisp,
+    rDisplayAll,
+    rOutputParsed,
+    rOutput,
+    getPlotNames,
+    getCaptions,
+  ) where
+
+import RlangQQ
+import RlangQQ.ParseKnitted
+
+import System.Directory
+import System.FilePath
+import Data.Maybe
+import Data.List
+import Text.Read
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Char8 as Char
+import qualified Data.ByteString.Base64 as Base64
+import IHaskell.Display
+import IHaskell.Display.Blaze () -- to confirm it's installed
+import qualified Text.Blaze.Html5 as H
+import qualified Text.Blaze.Html5.Attributes as H
+import Data.Monoid
+import Data.Char
+import Control.Monad
+import Data.Ord
+import Data.List.Split
+import Text.XFormat.Show hiding ((<>))
+import Control.Applicative
+import Control.Concurrent
+import Data.Monoid
+import Data.Typeable
+
+import Control.Concurrent.STM
+import Language.Haskell.TH.Quote
+
+-- | same as 'RlangQQ.r', but displays plots at the end too
+rDisp = QuasiQuoter { quoteExp = \s -> [| do
+  result <- $(quoteExp r s)
+  p <- rDisplayAll
+  atomically (writeTChan displayChan p)
+  return result
+  |] }
+
+rOutput :: IO [Int]
+rOutput = do
+  fs <- mapMaybe (readMaybe <=< stripPrefix "raw" <=< stripSuffix ".md")
+    <$> getDirectoryContents "Rtmp"
+  fs' <- forM fs $ \f -> (,f) <$> getModificationTime (showf ("Rtmp/raw"%Int%".md") f)
+  return $ map snd $ sortBy (flip (comparing fst)) fs'
+
+-- | like 'stripPrefix' except on the end
+stripSuffix :: String -> String -> Maybe String
+stripSuffix s x = fmap reverse $ stripPrefix (reverse s) $ reverse x
+
+rOutputParsed :: IO [KnitInteraction]
+rOutputParsed = do
+  ns <- rOutput
+  case ns of
+    [] -> return []
+    n : _ -> parseKnitted <$> readFile (showf ("Rtmp/raw"%Int%".md") n)
+
+
+getPlotNames :: IO [String]
+getPlotNames = do
+  interactions <- rOutputParsed
+  return [ p |  KnitInteraction _ is <- interactions, KnitImage _ p <- is ]
+            
+getCaptions :: IO [String]
+getCaptions = do
+  interactions <- rOutputParsed
+  return [ c |  KnitInteraction _ is <- interactions,
+                KnitImage c _ <- is,
+                not (isBoringCaption c) ]
+
+-- | true when the caption name looks like one knitr will automatically
+-- generate
+isBoringCaption :: String -> Bool
+isBoringCaption s = maybe False
+                      (all isDigit)
+                      (stripPrefix "plot of chunk unnamed-chunk-" s)
+
+rDisplayAll :: IO Display
+rDisplayAll = do
+ ns <- rOutputParsed
+ imgs <- sequence [ displayInteraction o | KnitInteraction _ os <- ns, o <- os]
+ display (mconcat imgs)
+
+
+displayInteraction :: KnitOutput -> IO Display
+displayInteraction (KnitPrint c) = display (plain c)
+displayInteraction (KnitWarning c) = display (plain c)
+displayInteraction (KnitError c) = display (plain c)
+displayInteraction (KnitAsIs c) = display (plain c)
+displayInteraction (KnitImage cap img) = do
+  let caption
+          | isBoringCaption cap = mempty
+          | otherwise = H.p (H.toMarkup cap)
+  encoded <- Base64.encode <$> B.readFile img
+  display $ H.img H.! H.src (H.unsafeByteStringValue
+                         -- assumes you use the default device which is png
+                        (Char.pack "data:image/png;base64," <> encoded))
+              <> caption

--- a/ihaskell-display/ihaskell-rlangqq/LICENSE
+++ b/ihaskell-display/ihaskell-rlangqq/LICENSE
@@ -1,0 +1,30 @@
+Copyright (c) 2013, Adam Vogt <vogt.adam@gmail.com>
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Adam Vogt <vogt.adam@gmail.com> nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/ihaskell-display/ihaskell-rlangqq/Setup.hs
+++ b/ihaskell-display/ihaskell-rlangqq/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/ihaskell-display/ihaskell-rlangqq/ihaskell-rlangqq.cabal
+++ b/ihaskell-display/ihaskell-rlangqq/ihaskell-rlangqq.cabal
@@ -1,0 +1,28 @@
+name:                ihaskell-rlangqq
+version:             0.1.0.0
+synopsis:            a rDisp quasiquote to show plots from Rlang-QQ in IHaskell 
+license:             BSD3
+license-file:        LICENSE
+author:              Adam Vogt <vogt.adam@gmail.com>
+maintainer:          Adam Vogt <vogt.adam@gmail.com>
+category:            Development
+build-type:          Simple
+cabal-version:       >=1.10
+
+library
+  exposed-modules:     IHaskell.Display.Rlangqq
+  other-extensions:    TupleSections, TemplateHaskell
+  build-depends:       base <5,
+                       Rlang-QQ >=0.2 && <0.3,
+                       directory >=1.2 && <1.3,
+                       filepath >=1.3 && <1.4,
+                       bytestring >=0.10 && <0.11,
+                       base64-bytestring >=1.0 && <1.1,
+                       ihaskell >=0.3 && <0.4,
+                       ihaskell-blaze >=0.1 && <0.2,
+                       blaze-html >=0.6 && <0.7,
+                       split >=0.2 && <0.3,
+                       stm   -any,
+                       xformat >=0.1 && <0.2,
+                       template-haskell >= 2.8
+  default-language:    Haskell2010

--- a/ihaskell.cabal
+++ b/ihaskell.cabal
@@ -54,7 +54,7 @@ library
   default-language:    Haskell2010
   build-depends:       
                        base                 ==4.6.*,
-                       aeson                >=0.7,
+                       aeson                >=0.6 && < 0.8,
                        base64-bytestring    >=1.0,
                        bytestring           >=0.10,
                        cereal               ==0.3.*,
@@ -87,9 +87,17 @@ library
                        tar                  -any,
                        transformers         -any,
                        unix                 >= 2.6,
-                       utf8-string          -any
+                       unordered-containers -any,
+                       stm                  -any,
+                       text                 -any,
+                       utf8-string          -any,
+                       vector               -any
 
   exposed-modules: IHaskell.Display
+                   IHaskell.Convert
+                   IHaskell.Convert.Args
+                   IHaskell.Convert.IpynbToLhs
+                   IHaskell.Convert.LhsToIpynb
                    IHaskell.Eval.Completion
                    IHaskell.Eval.Evaluate
                    IHaskell.Eval.Info
@@ -107,26 +115,7 @@ library
 
 executable IHaskell
   -- .hs or .lhs file containing the Main module.
-  hs-source-dirs:      src
-  main-is:             Main.hs
-
-  build-tools:         happy, cpphs
-  
-  -- Modules included in this executable, other than Main.
-  other-modules:       
-             IHaskell.Eval.Lint
-             IHaskell.Eval.Completion
-             IHaskell.Eval.Info
-             IHaskell.Eval.Evaluate
-             IHaskell.Eval.Parser
-             IHaskell.Eval.Hoogle
-             IHaskell.Eval.ParseShell
-             IHaskell.Eval.Util
-             IHaskell.IPython
-             IHaskell.Flags
-             IHaskell.Types
-             IHaskell.Display
-             IHaskell.BrokenPackages
+  main-is:             src/Main.hs
 
   default-extensions: DoAndIfThenElse
   
@@ -134,40 +123,18 @@ executable IHaskell
   default-language:    Haskell2010
   build-depends:       
                        base                 ==4.6.*,
-                       aeson                >=0.7,
-                       base64-bytestring    >=1.0,
+                       aeson                >=0.6 && < 0.8,
                        bytestring           >=0.10,
                        cereal               ==0.3.*,
                        classy-prelude       >=0.7,
-                       cmdargs              >=0.10,
                        containers           >=0.5,
                        directory            -any,
-                       filepath             -any,
                        ghc                  ==7.6.*,
-                       ghc-parser           >=0.1.1,
-                       ghci-lib             >=0.1,
-                       ghc-paths            ==0.1.*,
-                       haskeline            -any,
-                       here                 -any,
-                       hlint                -any,
-                       hspec                -any,
-                       HTTP                 -any,
-                       HUnit                -any,
+                       ihaskell             -any,
                        ipython-kernel       -any,
                        MissingH             >=1.2,
-                       mtl                  >=2.1,
-                       parsec               -any,
-                       process              >=1.1,
-                       random               >=1.0,
-                       shelly               ==1.3.* || >= 1.4.4.2,
-                       split                >= 0.2,
-                       strict               >=0.3,
-                       system-argv0         -any,
-                       system-filepath      -any,
-                       tar                  -any,
-                       transformers         -any,
-                       unix                 >= 2.6,
-                       utf8-string          -any
+                       text                 -any,
+                       unix                 >= 2.6
 
 Test-Suite hspec
   hs-source-dirs:      src
@@ -177,7 +144,7 @@ Test-Suite hspec
   default-language:    Haskell2010
   build-depends:       
                        base                 ==4.6.*,
-                       aeson                >=0.7,
+                       aeson                >=0.6 && < 0.8,
                        base64-bytestring    >=1.0,
                        bytestring           >=0.10,
                        cereal               ==0.3.*,

--- a/ipython-kernel/ipython-kernel.cabal
+++ b/ipython-kernel/ipython-kernel.cabal
@@ -27,7 +27,7 @@ library
   hs-source-dirs:      src
   default-language:    Haskell2010
   build-depends:       base            >=4.6 && <4.7,
-                       aeson           >=0.7,
+                       aeson           >=0.6 && <0.8,
                        bytestring      >=0.10,
                        cereal          ==0.3.*,
                        containers      >=0.5,

--- a/ipython-kernel/src/IPython/Message/Parser.hs
+++ b/ipython-kernel/src/IPython/Message/Parser.hs
@@ -11,9 +11,9 @@ import            Control.Applicative   ((<|>))
 import            Data.Aeson.Types      (parse)
 import            Data.ByteString
 import            Data.Map              (Map)
-import qualified  Data.ByteString.Lazy  as Lazy
-import qualified  Data.ByteString.Char8 as Char
-import qualified  Data.Map              as Map
+import            Data.Text             (Text)
+
+import qualified  Data.ByteString.Lazy as Lazy
 
 import IPython.Types
 
@@ -45,10 +45,10 @@ parseHeader :: [ByteString]  -- ^ The list of identifiers.
 parseHeader idents headerData parentHeader metadata = MessageHeader {
   identifiers = idents,
   parentHeader = parentResult,
-  metadata = Map.map Char.pack $ Map.mapKeys Char.pack metadataMap,
+  metadata = metadataMap,
   messageId = messageUUID,
   sessionId = sessionUUID,
-  username = Char.pack username,
+  username = username,
   msgType = messageType
   } where
       -- Decode the header data and the parent header data into JSON objects.
@@ -67,7 +67,7 @@ parseHeader idents headerData parentHeader metadata = MessageHeader {
         return (messType, username, message, session)
 
       -- Get metadata as a simple map.
-      Just metadataMap = decode $ Lazy.fromStrict metadata :: Maybe (Map String String)
+      Just metadataMap = decode $ Lazy.fromStrict metadata :: Maybe (Map Text Text)
 
 noHeader :: MessageHeader
 noHeader = error "No header created"
@@ -108,7 +108,7 @@ executeRequestParser content =
       Success (code, silent, storeHistory, allowStdin) = parse parser decoded in
     ExecuteRequest {
       header = noHeader,
-      getCode = Char.pack code,
+      getCode = code,
       getSilent = silent,
       getAllowStdin = allowStdin,
       getStoreHistory = storeHistory,
@@ -123,7 +123,7 @@ completeRequestParser content = parsed
         code     <- obj .: "block" <|> return ""
         codeLine <- obj .: "line"
         pos      <- obj .: "cursor_pos"
-        return $ CompleteRequest noHeader (Char.pack code) (Char.pack codeLine) pos
+        return $ CompleteRequest noHeader code codeLine pos
 
   Just decoded = decode content
 

--- a/ipython-kernel/src/IPython/Message/Writer.hs
+++ b/ipython-kernel/src/IPython/Message/Writer.hs
@@ -11,8 +11,9 @@ import Data.Map     (Map)
 import Data.Text    (Text, pack)
 import Data.Monoid  (mempty)
 
-import qualified  Data.ByteString.Char8       as Char
-
+import qualified Data.ByteString.Lazy as L
+import qualified Data.ByteString as B
+import Data.Text.Encoding
 
 import IPython.Types
 
@@ -103,7 +104,8 @@ instance ToJSON StreamType where
 
 -- | Convert a MIME type and value into a JSON dictionary pair.
 displayDataToJson :: DisplayData -> (Text, Value) 
-displayDataToJson (DisplayData mimeType dataStr) = pack (show mimeType) .= Char.unpack dataStr
+displayDataToJson (DisplayData mimeType dataStr) =
+    pack (show mimeType) .= String dataStr
 
 ----- Constants -----
 

--- a/sources.txt.in
+++ b/sources.txt.in
@@ -1,0 +1,51 @@
+-- This sources.txt.in is processed by the c preprocessor
+-- to generate a sources.txt suitable for cabal-meta
+-- 
+-- The command to generate it is something like:
+-- 
+--  cpp -P -C -D_ALL -D_DISP < sources.txt.in > sources.txt
+
+./
+#ifdef _ALL
+./ipython-kernel
+./ghci-lib
+
+-- the ghc-parser on hackage is new enough, and cabal tries
+-- to recompile each time... other preprocessors don't have
+-- this problem
+-- ./ghc-parser
+
+#ifdef _DISP
+./ihaskell-display/ihaskell-aeson
+./ihaskell-display/ihaskell-basic
+./ihaskell-display/ihaskell-blaze
+./ihaskell-display/ihaskell-charts
+./ihaskell-display/ihaskell-diagrams
+./ihaskell-display/ihaskell-hatex
+./ihaskell-display/ihaskell-magic
+./ihaskell-display/ihaskell-rlangqq
+#ifdef _PULL
+https://github.com/diagrams/diagrams-core
+https://github.com/diagrams/diagrams-lib
+https://github.com/diagrams/diagrams-svg
+https://github.com/diagrams/diagrams-cairo
+https://github.com/diagrams/diagrams-postscript
+https://github.com/diagrams/diagrams-contrib
+https://github.com/diagrams/SVGFonts
+
+-- https://github.com/timbod7/haskell-chart
+-- when a forthcoming PR for the sources.txt gets added
+https://github.com/aavogt/haskell-chart
+#else
+./vendor/diagrams-core
+./vendor/diagrams-lib
+./vendor/diagrams-svg
+./vendor/diagrams-cairo
+./vendor/diagrams-postscript
+./vendor/diagrams-contrib
+./vendor/SVGFonts
+./vendor/haskell-chart
+#endif
+#endif
+
+#endif

--- a/src/IHaskell/Convert.hs
+++ b/src/IHaskell/Convert.hs
@@ -1,0 +1,33 @@
+-- | Description : mostly reversible conversion between ipynb and lhs 
+module IHaskell.Convert (convert) where
+import Control.Monad.Identity (Identity(Identity), unless, when)
+import IHaskell.Convert.Args (ConvertSpec(ConvertSpec, convertInput, convertLhsStyle, convertOutput, convertOverwriteFiles, convertToIpynb), fromJustConvertSpec, toConvertSpec)
+import IHaskell.Convert.IpynbToLhs (ipynbToLhs)
+import IHaskell.Convert.LhsToIpynb (lhsToIpynb)
+import IHaskell.Flags (Argument)
+import System.Directory (doesFileExist)
+import Text.Printf (printf)
+
+-- | used by @IHaskell convert@
+convert :: [Argument] -> IO ()
+convert args = case fromJustConvertSpec (toConvertSpec args) of
+  ConvertSpec { convertToIpynb = Identity toIpynb,
+                convertInput = Identity inputFile,
+                convertOutput = Identity outputFile,
+                convertLhsStyle = Identity lhsStyle,
+                convertOverwriteFiles = force }
+      | toIpynb -> do
+        unless force (failIfExists outputFile)
+        lhsToIpynb lhsStyle inputFile outputFile
+      | otherwise -> do
+        unless force (failIfExists outputFile)
+        ipynbToLhs lhsStyle inputFile outputFile
+
+-- | Call fail when the named file already exists.
+failIfExists :: FilePath -> IO ()
+failIfExists file = do
+  exists <- doesFileExist file
+  when exists $ fail $
+    printf "File %s already exists. To force supply --force." file
+
+

--- a/src/IHaskell/Convert/Args.hs
+++ b/src/IHaskell/Convert/Args.hs
@@ -1,0 +1,107 @@
+-- | Description: interpret flags parsed by "IHaskell.Flags"
+module IHaskell.Convert.Args
+  (ConvertSpec(..),
+   fromJustConvertSpec,
+   toConvertSpec,
+  ) where
+
+import Control.Applicative ((<$>))
+import Control.Monad.Identity (Identity(Identity))
+import Data.Char (toLower)
+import Data.List (partition)
+import Data.Maybe (fromMaybe)
+import qualified Data.Text.Lazy as T (pack, Text)
+import IHaskell.Flags (Argument(ConvertFrom, ConvertFromFormat, ConvertLhsStyle, ConvertTo, ConvertToFormat, OverwriteFiles), LhsStyle, lhsStyleBird, NotebookFormat(..))
+import System.FilePath ((<.>), dropExtension, takeExtension)
+import Text.Printf (printf)
+
+
+-- | ConvertSpec is the accumulator for command line arguments
+data ConvertSpec f = ConvertSpec
+  { convertToIpynb :: f Bool,
+    convertInput :: f FilePath,
+    convertOutput :: f FilePath,
+    convertLhsStyle :: f (LhsStyle T.Text),
+    convertOverwriteFiles :: Bool
+  }
+
+-- | Convert a possibly-incomplete specification for what to convert
+-- into one which can be executed. Calls error when data is missing.
+fromJustConvertSpec ::  ConvertSpec Maybe -> ConvertSpec Identity
+fromJustConvertSpec convertSpec = convertSpec {
+        convertToIpynb = Identity toIpynb,
+        convertInput = Identity inputFile,
+        convertOutput = Identity outputFile,
+        convertLhsStyle = Identity $ fromMaybe
+                                        (T.pack <$> lhsStyleBird)
+                                        (convertLhsStyle convertSpec)
+      }
+  where
+    toIpynb = fromMaybe (error "Error: direction for conversion unknown")
+                            (convertToIpynb convertSpec)
+    (inputFile, outputFile) = case (convertInput convertSpec, convertOutput convertSpec) of
+        (Nothing, Nothing) -> error "Error: no files specified for conversion"
+        (Just i, Nothing) | toIpynb -> (i, dropExtension i <.> "ipynb")
+                          | otherwise -> (i, dropExtension i <.> "lhs")
+        (Nothing, Just o) | toIpynb -> (dropExtension o <.> "lhs", o)
+                          | otherwise -> (dropExtension o <.> "ipynb", o)
+        (Just i, Just o) -> (i, o)
+
+-- | Does this @Argument@ explicitly request a file format?
+isFormatSpec ::  Argument -> Bool
+isFormatSpec (ConvertToFormat _) = True
+isFormatSpec (ConvertFromFormat _) = True
+isFormatSpec _ = False
+
+
+toConvertSpec :: [Argument] -> ConvertSpec Maybe
+toConvertSpec args = mergeArgs otherArgs
+                                (mergeArgs formatSpecArgs initialConvertSpec)
+  where
+    (formatSpecArgs, otherArgs) = partition isFormatSpec args
+    initialConvertSpec = ConvertSpec Nothing Nothing Nothing Nothing False
+
+mergeArgs ::  [Argument] -> ConvertSpec Maybe -> ConvertSpec Maybe
+mergeArgs args initialConvertSpec = foldr mergeArg initialConvertSpec args
+
+mergeArg ::  Argument -> ConvertSpec Maybe -> ConvertSpec Maybe
+mergeArg OverwriteFiles convertSpec = convertSpec { convertOverwriteFiles = True }
+mergeArg (ConvertLhsStyle lhsStyle) convertSpec
+  | Just previousLhsStyle <- convertLhsStyle convertSpec,
+    previousLhsStyle /= fmap T.pack lhsStyle = error $ printf
+                                              "Conflicting lhs styles requested: <%s> and <%s>"
+                                              (show lhsStyle) (show previousLhsStyle)
+  | otherwise = convertSpec { convertLhsStyle = Just (T.pack <$> lhsStyle) }
+mergeArg (ConvertFrom inputFile) convertSpec
+  | Just previousInputFile <- convertInput convertSpec,
+    previousInputFile /= inputFile = error $ printf "Multiple input files specified: <%s> and <%s>"
+                                              inputFile previousInputFile
+  | otherwise = convertSpec {
+          convertInput = Just inputFile,
+          convertToIpynb = case (convertToIpynb convertSpec, fromExt inputFile) of
+                              (prev, Nothing) -> prev
+                              (prev @ (Just _), _) -> prev
+                              (Nothing, format) -> fmap (== LhsMarkdown) format
+        }
+
+mergeArg (ConvertTo outputFile) convertSpec
+  | Just previousOutputFile <- convertOutput convertSpec,
+    previousOutputFile /= outputFile = error $ printf "Multiple output files specified: <%s> and <%s>"
+                                              outputFile previousOutputFile
+  | otherwise = convertSpec {
+          convertOutput = Just outputFile,
+          convertToIpynb = case (convertToIpynb convertSpec, fromExt outputFile) of
+                              (prev, Nothing)         -> prev
+                              (prev @ (Just _), _) -> prev
+                              (Nothing, format) -> fmap (== IPYNB) format
+        }
+
+mergeArg unexpectedArg _ = error $ "IHaskell.Convert.mergeArg: impossible argument: "
+                                      ++ show unexpectedArg
+
+-- | Guess the format based on the file extension.
+fromExt ::  FilePath -> Maybe NotebookFormat
+fromExt s = case map toLower (takeExtension s) of
+  ".lhs" -> Just LhsMarkdown
+  ".ipynb" -> Just IPYNB
+  _ -> Nothing

--- a/src/IHaskell/Convert/IpynbToLhs.hs
+++ b/src/IHaskell/Convert/IpynbToLhs.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module IHaskell.Convert.IpynbToLhs (ipynbToLhs) where
+
+import Control.Applicative ((<$>))
+import Data.Aeson (decode, Object, Value(Array, Object, String))
+import qualified Data.ByteString.Lazy as L (readFile)
+import qualified Data.HashMap.Strict as M (lookup)
+import Data.Maybe (fromMaybe)
+import Data.Monoid ((<>), Monoid(mempty))
+import qualified Data.Text.Lazy as T (concat, fromStrict, Text, unlines)
+import qualified Data.Text.Lazy.IO as T (writeFile)
+import Data.Vector (Vector)
+import qualified Data.Vector as V (map, mapM, toList)
+import IHaskell.Flags (LhsStyle(lhsBeginCode, lhsBeginOutput, lhsCodePrefix, lhsEndCode, lhsEndOutput, lhsOutputPrefix))
+
+ipynbToLhs :: LhsStyle T.Text
+  -> FilePath -- ^ the filename of an ipython notebook
+  -> FilePath -- ^ the filename of the literate haskell to write
+  -> IO ()
+ipynbToLhs sty from to = do
+  Just (js :: Object) <- decode <$> L.readFile from
+  case M.lookup "worksheets" js of
+    Just (Array worksheets)
+      | [ Object worksheet ] <- V.toList worksheets,
+        Just (Array cells) <- M.lookup "cells" worksheet ->
+            T.writeFile to $ T.unlines $ V.toList
+              $ V.map (\(Object y) -> convCell sty y) cells
+    _ -> error "IHaskell.Convert.ipynbTolhs: json does not follow expected schema"  
+
+concatWithPrefix :: T.Text -- ^ the prefix to add to every line
+  -> Vector Value          -- ^ a json array of text lines
+  -> Maybe T.Text
+concatWithPrefix p arr = T.concat . map (p <>) . V.toList <$> V.mapM toStr arr
+
+toStr :: Value -> Maybe T.Text
+toStr (String x) = Just (T.fromStrict x)
+toStr _ = Nothing
+
+-- | @convCell sty cell@ converts a single cell in JSON into text suitable
+-- for the type of lhs file described by the @sty@
+convCell :: LhsStyle T.Text -> Object -> T.Text
+convCell _sty object
+  | Just (String "markdown") <- M.lookup "cell_type" object,
+    Just (Array xs)          <- M.lookup "source" object,
+    ~ (Just s) <- concatWithPrefix "" xs = s
+convCell sty object
+    | Just (String "code") <- M.lookup "cell_type" object,
+      Just (Array i)       <- M.lookup "input" object,
+      Just (Array o)       <- M.lookup "outputs" object,
+     ~ (Just i) <- concatWithPrefix (lhsCodePrefix sty) i,
+      o <- fromMaybe mempty (convOutputs sty o) = "\n" <>
+              lhsBeginCode sty <> i <> lhsEndCode sty <> "\n" <> o <> "\n"
+convCell _ _ = "IHaskell.Convert.convCell: unknown cell"
+
+convOutputs ::  LhsStyle T.Text
+  -> Vector Value -- ^ JSON array of output lines containing text or markup
+  -> Maybe T.Text
+convOutputs sty array = do
+  outputLines <- V.mapM (getTexts (lhsOutputPrefix sty)) array
+  return $ lhsBeginOutput sty <> T.concat (V.toList outputLines) <> lhsEndOutput sty
+
+getTexts ::  T.Text -> Value -> Maybe T.Text
+getTexts p (Object object)
+  | Just (Array text) <- M.lookup "text" object = concatWithPrefix p text
+getTexts _ _ = Nothing

--- a/src/IHaskell/Convert/LhsToIpynb.hs
+++ b/src/IHaskell/Convert/LhsToIpynb.hs
@@ -1,0 +1,103 @@
+{-# LANGUAGE OverloadedStrings #-}
+module IHaskell.Convert.LhsToIpynb (lhsToIpynb) where
+
+import Control.Applicative ((<$>))
+import Data.Aeson ((.=), encode, object, Value(Array, Bool, Number, String))
+import qualified Data.ByteString.Lazy as L (writeFile)
+import Data.Char (isSpace)
+import Data.Monoid (Monoid(mempty))
+import qualified Data.Text as TS (Text)
+import qualified Data.Text.Lazy as T (dropWhile, lines, stripPrefix, Text, toStrict)
+import qualified Data.Text.Lazy.IO as T (readFile)
+import qualified Data.Vector as V (fromList, singleton)
+import IHaskell.Flags (LhsStyle(LhsStyle))
+
+lhsToIpynb :: LhsStyle T.Text -> FilePath -> FilePath -> IO ()
+lhsToIpynb sty from to = do
+  classed <-  classifyLines sty . T.lines <$> T.readFile from
+  L.writeFile to . encode . encodeCells $ groupClassified classed
+
+data CellLine a = CodeLine a | OutputLine a | MarkdownLine a
+                deriving Show
+
+isCode ::  CellLine t -> Bool
+isCode (CodeLine _) = True
+isCode _ = False
+
+isOutput ::  CellLine t -> Bool
+isOutput (OutputLine _) = True
+isOutput _ = False
+
+isMD ::  CellLine t -> Bool
+isMD (MarkdownLine _) = True
+isMD _ = False
+
+isEmptyMD ::  (Eq a, Monoid a) => CellLine a -> Bool
+isEmptyMD (MarkdownLine a) = a == mempty
+isEmptyMD _ = False
+
+
+untag ::  CellLine t -> t
+untag (CodeLine a) = a
+untag (OutputLine a) = a
+untag (MarkdownLine a) = a
+
+data Cell a = Code a a | Markdown a
+            deriving (Show)
+
+encodeCells :: [Cell [T.Text]] -> Value
+encodeCells xs = object $
+  [ "worksheets" .= Array (V.singleton (object
+    [ "cells" .= Array (V.fromList (map cellToVal xs)) ] ))
+  ] ++ boilerplate
+
+cellToVal :: Cell [T.Text] -> Value
+cellToVal (Code i o) = object $
+  [ "cell_type" .= String "code",
+    "collapsed" .= Bool False,
+    "language" .= String "python", -- is what it IPython gives us
+    "metadata" .= object [],
+     "input" .= arrayFromTxt i,
+     "outputs" .= Array 
+        (V.fromList (
+           [ object ["text" .= arrayFromTxt o,
+             "metadata" .= object [],
+             "output_type" .= String "display_data" ]
+          | _ <- take 1 o])) ]
+
+cellToVal (Markdown txt) = object $
+  [ "cell_type" .= String "markdown",
+    "metadata" .= object [],
+    "source" .= arrayFromTxt txt ]
+
+-- | arrayFromTxt makes a JSON array of string s
+arrayFromTxt ::  [T.Text] -> Value
+arrayFromTxt i = Array (V.fromList (map (String . T.toStrict) i))
+
+-- | ihaskell needs this boilerplate at the upper level to interpret the
+-- json describing cells and output correctly.
+boilerplate :: [(TS.Text, Value)]
+boilerplate =
+  [ "metadata" .= object [ "language" .= String "haskell", "name" .= String ""],
+    "nbformat" .= Number 3,
+    "nbformat_minor" .= Number 0 ]
+
+groupClassified :: [CellLine T.Text] -> [Cell [T.Text]]
+groupClassified (CodeLine a : x)
+    | (c,x) <- span isCode x,
+      (_,x) <- span isEmptyMD x,
+      (o,x) <- span isOutput x = Code (a : map untag c) (map untag o) : groupClassified x
+groupClassified (MarkdownLine a : x)
+    | (m,x) <- span isMD x = Markdown (a: map untag m) : groupClassified x
+groupClassified (OutputLine a : x ) = Markdown [a] : groupClassified x
+groupClassified [] = []
+
+classifyLines :: LhsStyle T.Text -> [T.Text] -> [CellLine T.Text]
+classifyLines sty@(LhsStyle c o _ _ _ _) (l:ls) = case (sp c, sp o) of
+    (Just a, Nothing) -> CodeLine a : classifyLines sty ls
+    (Nothing, Just a) -> OutputLine a : classifyLines sty ls
+    (Nothing,Nothing) -> MarkdownLine l : classifyLines sty ls
+    _ -> error "IHaskell.Convert.classifyLines"
+  where sp c = T.stripPrefix (T.dropWhile isSpace c) (T.dropWhile isSpace l)
+classifyLines _ [] = []    
+

--- a/src/IHaskell/Display.hs
+++ b/src/IHaskell/Display.hs
@@ -1,24 +1,45 @@
 {-# LANGUAGE NoImplicitPrelude, OverloadedStrings, FlexibleInstances #-}
 module IHaskell.Display (
+  -- * How to get IHaskell to display different types
   IHaskellDisplay(..),
-  plain, html, png, jpg, svg, latex,
-  serializeDisplay,
-  Width, Height, Base64(..),
-  encode64, base64,
+  -- $displayDynCommentary
+  --
+  -- $displayDynExBad
+  displayDyn,
+  -- $displayChanCommentary
+  displayChan,
+
+  -- * Ways to create 'Display'
   Display(..),
   DisplayData(..),
+
+  plain, html, png, jpg, svg, latex,
+  Width, Height, Base64(..),
+  encode64, base64,
+
+  -- * for internal use
+  serializeDisplay,
+  displayClass,
+  displayFromDyn,
+  displayFromChan,
   ) where
 
 import ClassyPrelude
 import Data.Serialize as Serialize
-import Data.ByteString hiding (map)
+import Data.ByteString hiding (map, pack)
 import Data.String.Utils (rstrip) 
 import qualified Data.ByteString.Base64 as Base64
 import qualified Data.ByteString.Char8 as Char
 
+import Data.Dynamic
+import Data.Monoid
+import System.IO.Unsafe (unsafePerformIO)
 import IHaskell.Types
 
-type Base64 = ByteString
+import Control.Concurrent.STM.TChan
+import Control.Monad.STM
+
+type Base64 = Text -- ByteString would suffice
 
 -- | A class for displayable Haskell types.
 --
@@ -53,25 +74,63 @@ instance IHaskellDisplay a => IHaskellDisplay [a] where
     displays <- mapM display disps
     return $ ManyDisplay displays
 
+-- | see 'displayDyn'
+displayFromDyn :: Typeable a => a -> IO (Maybe Display)
+displayFromDyn x = do
+     fs <- readMVar displayDyn 
+     let go [] = return Nothing
+         go (f:fs) = do
+            fx <- f (toDyn x)
+            case fx of
+                First Nothing -> go fs
+                First (Just y) -> return (Just y)
+     go fs
+
+
+-- IHaskell tries to apply functions from this list when displaying things:
+-- the first function that produces a 'Display' (rather than @First Nothing@)
+-- is used.
+{-# NOINLINE displayDyn #-}
+displayDyn :: MVar [Dynamic -> IO (First Display)]
+displayDyn = unsafePerformIO (newMVar [])
+
+-- | Items written to this chan will be included in the output sent
+-- to the frontend (ultimately the browser), the next time IHaskell
+-- has an item to display.
+{-# NOINLINE displayChan #-}
+displayChan :: TChan Display
+displayChan = unsafePerformIO newTChanIO
+
+-- | Take everything that was put into the 'displayChan' at that point
+-- out, and make a 'Display' out of it.
+displayFromChan :: IO (Maybe Display)
+displayFromChan =
+    Just . many <$> unfoldM (atomically (tryReadTChan displayChan))
+
+-- | This is unfoldM from monad-loops. It repeatedly runs an IO action
+-- until it return Nothing, and puts all the Justs in a list.
+unfoldM :: IO (Maybe a) -> IO [a]
+unfoldM f = maybe (return []) (\r -> (r:) <$> unfoldM f) =<< f
+
 -- | Encode many displays into a single one. All will be output.
 many :: [Display] -> Display
 many = ManyDisplay
 
 -- | Generate a plain text display.
 plain :: String -> DisplayData
-plain = DisplayData PlainText . Char.pack . rstrip
+plain = DisplayData PlainText . pack . rstrip
 
 -- | Generate an HTML display.
 html :: String -> DisplayData
-html = DisplayData MimeHtml . Char.pack
+html = DisplayData MimeHtml . pack
 
 -- | Genreate an SVG display.
 svg :: String -> DisplayData
-svg = DisplayData MimeSvg . Char.pack
+svg = DisplayData MimeSvg . pack
 
 -- | Genreate a LaTeX display.
 latex :: String -> DisplayData
-latex = DisplayData MimeLatex . Char.pack
+latex = DisplayData MimeLatex . pack
 
 -- | Generate a PNG display of the given width and height. Data must be
 -- provided in a Base64 encoded manner, suitable for embedding into HTML.
@@ -91,9 +150,103 @@ encode64 str = base64 $ Char.pack str
 
 -- | Convert from a ByteString into base 64 encoded data.
 base64 :: ByteString -> Base64
-base64 = Base64.encode
+base64 = decodeUtf8 . Base64.encode
 
 -- | For internal use within IHaskell.
 -- Serialize displays to a ByteString.
-serializeDisplay :: Display -> ByteString
+serializeDisplay :: Maybe Display -> ByteString
 serializeDisplay = Serialize.encode
+
+-- | This variation of 'display' that always has a 'Just' is used to
+-- simplify code in "IHaskell.Eval.Evaluate", which needs to handle
+-- the case when 'displayFromDyn' does not find a function to display.
+displayClass :: IHaskellDisplay a => a -> IO (Maybe Display) 
+displayClass = fmap Just . display
+
+{- $displayDynCommentary
+
+There is some overlap between what you can do with 'displayDyn' and what
+you can do by writing an instance of 'IHaskellDisplay'. The following is a
+comparison of the two approaches.
+
+Suppose that we want to display images generated in the IHaskell notebook,
+and that they are defined:
+
+> newtype Image = Image ByteString deriving Typeable
+
+One function that can make a 'Display' out of 'Image' is:
+
+> displayImage :: Int -> Int -> Image -> IO Display
+> displayImage w h (Image x) = display (png w h (base64 x))
+
+It is straightforward to define an IHaskellDisplay instance. This one
+assumes you always want a fixed image size:
+
+> instance IHaskellDisplay DynamicImage where
+>  display = displayImage 640 480
+
+The equivalent results can be achieved with the 'displayDyn' MVar too. 
+
+> -- first a utility function that applies displayImage iff the
+> -- the Dynamic contains an Image
+> handleImage :: Int -> Int -> Dynamic -> IO (First Display)
+> handleImage w h = fmap First . traverse (displayImage w h) . fromDynamic
+>
+> -- then in the notebook you can add a
+> modifyMVar_ displayDyn (return . (handleImage 640 480 :))
+
+Then later on after making some pictures, you can add another
+function that will be used instead:
+
+> modifyMVar_ displayDyn (return . (handleImage 1280 800 :))
+
+To approach displayDyn version, you would have to write all
+IHaskellDisplay instances using a global variable containing
+the function that is actually used. A minor issue is that you cannot remove
+instances, but you can remove elements from the list referenced by
+'displayDyn'
+-}
+
+-- this one is separate because of a haddock bug
+-- http://trac.haskell.org/haddock/ticket/282
+
+-- $displayDynExBad
+--
+-- > {-# NOINLINE imageDisplay #-}
+-- > displayImageRef :: IORef (Image -> IO Display)
+-- > displayImageRef = unsafePerformIO (displayImage 640 480)
+-- >
+-- > instance IHaskellDisplay Image where
+-- >   display img = do
+-- >       fn <- readIORef displayImageRef
+-- >       fn img 
+
+{- $displayChanCommentary
+
+In the notebook, writes to stdout are captured and 'display'ed later
+on. Without 'displayChan', this functionality is available if the output is
+in some format besides plain text. In other words, a function might be:
+
+> histWithPlot :: Vector Double -> IO (Vector Int, Display)
+
+Then in the notebook, users have to explicitly handle that argument:
+
+> (binnedCounts, showPlot) <- histWithPlot ys
+> showPlot
+> .. do stuff with binnedCounts ..
+
+If we instead define a new @histWithPlot'@ that sends the image to
+'displayChan':
+
+> histWithPlot' :: Vector Double -> IO (Vector Int)
+> histWithPlot' ys = do
+>     (binnedCounts, showPlot) <- histWithPlot ys
+>     writeTChan displayChan showPlot
+>     return binnedCounts
+
+Then code in the notebook is \"better\"
+
+> binnedCounts <- histWithPlot ys
+> .. do stuff with binnedCounts ...
+
+-}

--- a/src/IHaskell/Eval/Evaluate.hs
+++ b/src/IHaskell/Eval/Evaluate.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE DoAndIfThenElse, NoOverloadedStrings, TypeSynonymInstances #-}
+{-# LANGUAGE DoAndIfThenElse, NoOverloadedStrings, TypeSynonymInstances,
+   ScopedTypeVariables #-}
 
 {- | Description : Wrapper around GHC API, exposing a single `evaluate` interface that runs
                    a statement, declaration, import, or directive.
@@ -26,7 +27,7 @@ import System.Posix.IO
 import System.IO (hGetChar, hFlush)
 import System.Random (getStdGen, randomRs)
 import Unsafe.Coerce
-import Control.Monad (guard)
+import Control.Monad (guard, msum)
 import System.Process
 import System.Exit
 import Data.Maybe (fromJust)
@@ -51,7 +52,7 @@ import GhcMonad (liftIO, withSession)
 import GHC hiding (Stmt, TypeSig)
 import GHC.Paths
 import Exception hiding (evaluate)
-import Outputable
+import Outputable hiding ((<>))
 import Packages
 import Module
 import qualified Pretty
@@ -60,6 +61,7 @@ import Bag
 import ErrUtils (errMsgShortDoc, errMsgExtraInfo)
 
 import qualified System.IO.Strict as StrictIO
+import Control.Monad.Error (ErrorT(..),mplus,throwError)
 
 import IHaskell.Types
 import IHaskell.IPython
@@ -662,26 +664,31 @@ evalCommand output (Expression expr) state = do
   -- Dislay If typechecking fails and there is no appropriate
   -- typeclass instance, this will throw an exception and thus `attempt` will
   -- return False, and we just resort to plaintext.
-  let displayExpr = printf "(IHaskell.Display.display (%s))" expr :: String
-  canRunDisplay <- attempt $ exprType displayExpr
+  let displayClass = printf "(IHaskell.Display.displayClass (%s))" expr :: String
+  let displayMVar  = printf "(IHaskell.Display.displayFromDyn (%s))" expr :: String
+  let displayChan  = printf "IHaskell.Display.displayFromChan" :: String
 
-  if canRunDisplay
-  then useDisplay displayExpr
-  else do
-    -- Evaluate this expression as though it's just a statement.
-    -- The output is bound to 'it', so we can then use it.
-    evalOut <- evalCommand output (Statement expr) state
-
-    let out = evalResult evalOut
-        showErr = isShowError out
-
-    -- If evaluation failed, return the failure.  If it was successful, we
-    -- may be able to use the IHaskellDisplay typeclass.
-    return $ if not showErr || useShowErrors state
-            then evalOut
-            else postprocessShowError evalOut
-
+  Right result <- runErrorT $ msum
+        [tryDisplay displayMVar,
+         tryDisplay displayClass,
+         lift fallback]
+  fromChan <- runErrorT (tryDisplay displayChan)
+  return $ appendEvalResult result (either mempty evalResult fromChan)
   where
+    appendEvalResult x y = x{ evalResult = evalResult x <> y }
+    fallback = do
+      -- Evaluate this expression as though it's just a statement.
+      -- The output is bound to 'it', so we can then use it.
+      evalOut <- evalCommand output (Statement expr) state
+
+      let out = evalResult evalOut
+          showErr = isShowError out
+
+      -- If evaluation failed, return the failure.  If it was successful, we
+      -- may be able to use the IHaskellDisplay typeclass.
+      return $ if not showErr || useShowErrors state
+              then evalOut
+              else postprocessShowError evalOut
     -- Try to evaluate an action. Return True if it succeeds and False if
     -- it throws an exception. The result of the action is discarded.
     attempt :: Interpreter a -> Interpreter Bool
@@ -705,7 +712,10 @@ evalCommand output (Expression expr) state = do
     removeSvg (Display disps) = Display $ filter (not . isSvg) disps
     removeSvg (ManyDisplay disps) = ManyDisplay $ map removeSvg disps
 
-    useDisplay displayExpr = do
+    tryDisplay :: String -> ErrorT String Interpreter EvalOut
+    tryDisplay displayExpr = do
+     True <- lift (attempt (exprType displayExpr))
+     ErrorT $ ghandle (\ (e :: SomeException) -> return (Left (show e))) $ do
       -- If there are instance matches, convert the object into
       -- a Display. We also serialize it into a bytestring. We get
       -- the bytestring IO action as a dynamic and then convert back to
@@ -722,8 +732,8 @@ evalCommand output (Expression expr) state = do
                          else "let { it = %s }"
       evalOut <- evalCommand output (Statement $ printf stmtTemplate expr) state
       case evalStatus evalOut of
-        Failure -> return evalOut
-        Success -> wrapExecution state $ do
+        Failure -> return (Right evalOut)
+        Success -> do
           -- Compile the display data into a bytestring.
           let compileExpr = "fmap IHaskell.Display.serializeDisplay (IHaskell.Display.display it)"
           displayedBytestring <- dynCompileExpr compileExpr
@@ -735,13 +745,20 @@ evalCommand output (Expression expr) state = do
               bytestring <- liftIO bytestringIO
               case Serialize.decode bytestring of
                 Left err -> error err
-                Right display ->
-                  return $
+                Right Nothing -> return (Left "Nothing to display")
+                Right (Just display) ->
+                  return $ Right $ wrapE $
                     if useSvg state
                     then display :: Display
                     else removeSvg display
 
     isIO expr = attempt $ exprType $ printf "((\\x -> x) :: IO a -> IO a) (%s)" expr
+
+    wrapE res = EvalOut {
+      evalStatus = Success,
+      evalResult = res,
+      evalState = state,
+      evalPager = "" }
 
     postprocessShowError :: EvalOut -> EvalOut
     postprocessShowError evalOut = evalOut { evalResult = Display $ map postprocess disps }

--- a/src/IHaskell/Flags.hs
+++ b/src/IHaskell/Flags.hs
@@ -1,8 +1,12 @@
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 module IHaskell.Flags ( 
   IHaskellMode(..),
   Argument(..),
   Args(..),
+  LhsStyle(..),
+  lhsStyleBird,
+  NotebookFormat(..),
   parseFlags,
   help,
   ) where
@@ -23,8 +27,29 @@ data Argument
   | Extension String    -- ^ An extension to load at startup.
   | ConfFile String     -- ^ A file with commands to load at startup.
   | IPythonFrom String  -- ^ Which executable to use for IPython.
+  | OverwriteFiles      -- ^ Present when output should overwrite existing files. 
+  | ConvertFrom String
+  | ConvertTo String 
+  | ConvertFromFormat NotebookFormat
+  | ConvertToFormat   NotebookFormat
+  | ConvertLhsStyle   (LhsStyle String)
   | Help                -- ^ Display help text.
   deriving (Eq, Show)
+
+data LhsStyle string = LhsStyle
+  { lhsCodePrefix   :: string, -- ^ @>@
+    lhsOutputPrefix :: string, -- ^ @<<@
+    lhsBeginCode    :: string, -- ^ @\\begin{code}@
+    lhsEndCode      :: string, -- ^ @\\end{code}@
+    lhsBeginOutput  :: string, -- ^ @\\begin{verbatim}@
+    lhsEndOutput    :: string  -- ^ @\\end{verbatim}@
+  }
+  deriving (Eq, Functor, Show)
+
+data NotebookFormat
+  = LhsMarkdown
+  | IPYNB
+  deriving (Eq,Show)
 
 -- Which mode IHaskell is being invoked in.
 -- `None` means no mode was specified.
@@ -32,6 +57,7 @@ data IHaskellMode
   = ShowHelp String
   | Notebook
   | Console
+  | ConvertLhs
   | Kernel (Maybe String)
   | View (Maybe ViewFormat) (Maybe String)
   deriving (Eq, Show)
@@ -49,6 +75,7 @@ help mode =
     chooseMode Console = console
     chooseMode Notebook = notebook
     chooseMode (Kernel _) = kernel
+    chooseMode ConvertLhs = convert
 
 ipythonFlag :: Flag Args
 ipythonFlag = 
@@ -75,10 +102,51 @@ notebook = mode "notebook" (Args Notebook []) "Browser-based notebook interface.
 console :: Mode Args
 console = mode "console" (Args Console []) "Console-based interactive repl." noArgs $ ipythonFlag:universalFlags
 
+kernel :: Mode Args
 kernel = mode "kernel" (Args (Kernel Nothing) []) "Invoke the IHaskell kernel." kernelArg []
   where
     kernelArg = flagArg update "<json-kernel-file>"
     update filename (Args _ flags) = Right $ Args (Kernel $ Just filename) flags
+
+convert :: Mode Args
+convert = mode "convert" (Args ConvertLhs []) description unnamedArg convertFlags
+  where
+    description = "Convert between literate haskell (lhs) and ipython notebooks (ipynb)."
+    convertFlags = universalFlags
+      ++ [ flagReq ["input","i"] (store ConvertFrom) "<file>" "File to read.",
+           flagReq ["output","o"] (store ConvertTo) "<file>" "File to write.",
+           flagReq ["from","f"] (storeFormat ConvertFromFormat) "lhs|ipynb" "Format of the file to read.",
+           flagReq ["to","t"] (storeFormat ConvertToFormat) "lhs|ipynb" "Format of the file to write.",
+           flagNone ["force"] consForce "Overwrite existing files with output.",
+           flagReq ["style","s"] storeLhs "bird|tex" "Type of markup used for the literate haskell file",
+           flagNone ["bird"] (consStyle lhsStyleBird) "Literate haskell uses >",
+           flagNone ["tex"]  (consStyle lhsStyleTex ) "Literate haskell uses \\begin{code}"
+         ]
+
+    consForce (Args mode prev) = Args mode (OverwriteFiles : prev)
+
+    unnamedArg = Arg (store ConvertFrom) "<file>" False
+
+    consStyle style (Args mode prev) = Args mode (ConvertLhsStyle style : prev)
+
+    storeFormat constructor str (Args mode prev) = case toLower str of
+      "lhs" -> Right $ Args mode $ constructor LhsMarkdown : prev
+      "ipynb" -> Right $ Args mode $ constructor IPYNB : prev
+      _ -> Left ("Unknown format requested: " ++ str)
+
+    storeLhs str previousArgs = case toLower str of
+      "bird" -> success lhsStyleBird
+      "tex" -> success lhsStyleTex
+      _ -> Left ("Unknown lhs style: " ++ str)
+      where
+        success lhsStyle = Right $ consStyle lhsStyle previousArgs
+
+
+lhsStyleBird, lhsStyleTex :: LhsStyle String
+lhsStyleBird = LhsStyle "> " "\n<< " "" "" "" ""
+lhsStyleTex  = LhsStyle "" "" "\\begin{code}" "\\end{code}"
+                    "\\begin{verbatim}" "\\end{verbatim}"
+
 
 view :: Mode Args
 view =
@@ -116,7 +184,7 @@ ihaskellArgs =
       helpStr = showText (Wrap 100) $ helpText [] HelpFormatAll ihaskellArgs
       onlyHelp = [flagHelpSimple (add Help)]
       noMode = mode "IHaskell" (Args (ShowHelp helpStr) []) descr noArgs onlyHelp in
-    noMode { modeGroupModes = toGroup [console, notebook, view, kernel] }
+    noMode { modeGroupModes = toGroup [console, notebook, view, kernel, convert] }
   where 
     add flag (Args mode flags) = Args mode $ flag : flags
 

--- a/src/IHaskell/Types.hs
+++ b/src/IHaskell/Types.hs
@@ -80,6 +80,9 @@ instance Monoid Display where
     a             `mappend` ManyDisplay b = ManyDisplay (a : b)
     a             `mappend` b             = ManyDisplay [a,b]
 
+instance Semigroup Display where
+    a <> b = a `mappend` b
+
 -- | All state stored in the kernel between executions.
 data KernelState = KernelState
   { getExecutionCounter :: Int,

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -11,7 +11,7 @@ import Prelude        (last, read)
 import            Control.Concurrent        (threadDelay)
 import            Control.Concurrent.Chan
 import            Data.Aeson
-import            Data.String.Utils         (strip)
+import            Data.Text                 (strip)
 import            System.Directory
 import            System.Exit               (exitSuccess)
 import            Text.Printf
@@ -19,6 +19,7 @@ import            System.Posix.Signals
 import qualified  Data.Map                  as Map
 
 -- IHaskell imports.
+import            IHaskell.Convert          (convert)
 import            IHaskell.Eval.Completion  (complete)
 import            IHaskell.Eval.Evaluate
 import            IHaskell.Display
@@ -34,7 +35,6 @@ import qualified  IPython.Stdin             as Stdin
 
 -- GHC API imports.
 import GHC        hiding (extensions, language)
-import Outputable (showSDoc, ppr)
 
 -- | Compute the GHC API version number using the dist/build/autogen/cabal_macros.h
 ghcVersionInts :: [Int]
@@ -61,6 +61,8 @@ ihaskell :: Args -> IO ()
 -- If no mode is specified, print help text.
 ihaskell (Args (ShowHelp help) _) =
   putStrLn $ pack help
+
+ihaskell (Args ConvertLhs args) = convert args
 
 ihaskell (Args Console flags) = showingHelp Console flags $ do
   ipython <- chooseIPython flags
@@ -274,9 +276,9 @@ replyTo interface req@ExecuteRequest{ getCode = code } replyHeader state = do
         header <- dupHeader replyHeader DisplayDataMessage
         send $ PublishDisplayData header "haskell" $ map convertSvgToHtml outs
 
-      convertSvgToHtml (DisplayData MimeSvg svg) = html $ makeSvgImg $ base64 svg
+      convertSvgToHtml (DisplayData MimeSvg svg) = html $ makeSvgImg $ base64 $ encodeUtf8 svg
       convertSvgToHtml x = x
-      makeSvgImg base64data = Chars.unpack $ "<img src=\"data:image/svg+xml;base64," ++ base64data ++ "\"/>"
+      makeSvgImg base64data = unpack $ "<img src=\"data:image/svg+xml;base64," ++ base64data ++ "\"/>"
 
       publish :: EvaluationResult -> IO ()
       publish result = do
@@ -310,9 +312,9 @@ replyTo interface req@ExecuteRequest{ getCode = code } replyHeader state = do
   let execCount = getExecutionCounter state
   -- Let all frontends know the execution count and code that's about to run
   inputHeader <- liftIO $ dupHeader replyHeader InputMessage
-  send $ PublishInput inputHeader (Chars.unpack code) execCount
+  send $ PublishInput inputHeader (unpack code) execCount
   -- Run code and publish to the frontend as we go.
-  updatedState <- evaluate state (Chars.unpack code) publish
+  updatedState <- evaluate state (unpack code) publish
 
   -- Notify the frontend that we're done computing.
   idleHeader <- liftIO $ dupHeader replyHeader StatusMessage
@@ -328,16 +330,16 @@ replyTo interface req@ExecuteRequest{ getCode = code } replyHeader state = do
 
 
 replyTo _ req@CompleteRequest{} replyHeader state = do
-  let line = Chars.unpack $ getCodeLine req
-  (matchedText, completions) <- complete line (getCursorPos req)
+  let line = getCodeLine req
+  (matchedText, completions) <- complete (unpack line) (getCursorPos req)
 
-  let reply =  CompleteReply replyHeader completions matchedText line True
+  let reply =  CompleteReply replyHeader (map pack completions) (pack matchedText) line True
   return (state,  reply)
 
 -- | Reply to the object_info_request message. Given an object name, return
 -- | the associated type calculated by GHC.
 replyTo _ ObjectInfoRequest{objectName = oname} replyHeader state = do
-  docs <- info oname
+  docs <- pack <$> info (unpack oname)
   let reply = ObjectInfoReply {
                 header = replyHeader,
                 objectName = oname,


### PR DESCRIPTION
- Add displayDyn, which allows manipulating the functions used to
  convert items into Display in ways that would be impossible or
  at least ackward with IHaskellDisplay.
- Add displayChan, which allows sending Display items as a
  side-effect. ihaskell-rlangqq uses that feature.
- Add mode convert that handles ipynb <=> lhs. Some bad style is left
  over.
- Alternative build.sh
- JSON is defined over text, not bytes, so use Text in the
  ipython-kernel. IPython rarely calls encode(self,'utf-8'),
  so we should also have encoding done once only by the json parser
  itself too.
