### PR TITLE
allow ipython version 3

### DIFF
--- a/src/IHaskell/IPython.hs
+++ b/src/IHaskell/IPython.hs
@@ -181,6 +181,7 @@ setupIPython DefaultIPython = do
     checkIPythonVersion path = do
       output <- unpack <$> shelly (silently $ run path ["--version"])
       case parseVersion output of
+        Just (3:_) -> putStrLn "Using system-wide dev version of IPython."
         Just (2:_) -> putStrLn "Using system-wide IPython."
         Just (1:_) -> badIPython "Detected old version of IPython. IHaskell requires 2.0.0 or up."
         Just (0:_) -> badIPython "Detected old version of IPython. IHaskell requires 2.0.0 or up."


### PR DESCRIPTION
I've been working on ipython master ([at version 3](https://github.com/ipython/ipython/blob/master/IPython/core/release.py#L22)), and don't think there'd be a problem with allowing IHaskell to use it.
