### PR TITLE
Add missing dependency

### DIFF
--- a/ihaskell-display/ihaskell-magic/ihaskell-magic.cabal
+++ b/ihaskell-display/ihaskell-magic/ihaskell-magic.cabal
@@ -68,6 +68,7 @@ library
                        bytestring,
                        utf8-string,
                        base64-bytestring,
+                       ipython-kernel,
                        ihaskell >= 0.4
   
   -- Directories containing source files.


### PR DESCRIPTION
`ihaskell-magic` does not compile at all otherwise.
