### PR TITLE
homebrew haskell platform deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ If you do not have GHC or Cabal, you should be able to install both via the
 [Haskell Platform](http://www.haskell.org/platform/). On Macs with Homebrew, you can do this via
 ```bash
 # Macs with Homebrew only, if you don't have GHC or Cabal
-brew install haskell-platform
+brew install ghc cabal-install
 cabal update && cabal install cabal-install
 ```
 Use `cabal install cabal-install` to update Cabal if you still have version 1.16 instead of 1.18.


### PR DESCRIPTION
Brew says: 

```
$ brew install haskell-platform
Error: No available formula for haskell-platform
We no longer package haskell-platform. Consider installing ghc
and cabal-install instead:
  brew install ghc cabal-install

A binary installer is available:
  https://www.haskell.org/platform/mac.html
```
