### PR TITLE
[WIP] make custom.js work with 3.0

### DIFF
--- a/profile/static/custom/custom.js
+++ b/profile/static/custom/custom.js
@@ -1,4 +1,10 @@
-$([IPython.events]).on('notebook_loaded.Notebook', function(){
+console.warn('haskell custom js loading')
+require(['require', 'codemirror/lib/codemirror','codemirror/addon/mode/loadmode', 'base/js/namespace','base/js/events', 'base/js/utils'],function(require, CodeMirror, CodemirrorLoadmode, IPtyhon, events, utils){
+
+
+
+events.on('notebook_loaded.Notebook', function(){
+    console.warn('haskell custom js set metadata');
     // add here logic that should be run once per **notebook load**
     // (!= page load), like restarting a checkpoint
 
@@ -11,7 +17,9 @@ $([IPython.events]).on('notebook_loaded.Notebook', function(){
     }
 });
 
-$([IPython.events]).on('app_initialized.NotebookApp', function(){
+
+events.on('app_initialized.NotebookApp', function(){
+    console.warn('haskell custom js patches');
     // add here logic that shoudl be run once per **page load**
     // like adding specific UI, or changing the default value
     // of codecell highlight.
@@ -26,9 +34,10 @@ $([IPython.events]).on('app_initialized.NotebookApp', function(){
 
     IPython.CodeCell.options_default['cm_config']['mode'] = 'haskell';
     
-    CodeMirror.requireMode('haskell', function(){
+    utils.requireCodeMirrorMode('haskell', function(){
         // Create a multiplexing mode that uses Haskell highlighting by default but
         // doesn't highlight command-line directives.
+        console.warn('defining IHaskell mode');
         CodeMirror.defineMode("ihaskell", function(config) {
             return CodeMirror.multiplexingMode(
                 CodeMirror.getMode(config, "haskell"),
@@ -89,3 +98,5 @@ $([IPython.events]).on('shell_reply.Kernel', function() {
             });
     });
 });
+
+}); // end require


### PR DESCRIPTION
Hi, 

These are the modification I had to do for custom.js to work on 3.0, 
need a little more work to have them also work on 2.3 without changes, 
but just in case you want to try. 

You should "just" need the following also: 
```
$ cat .ipython/kernels/haskell/kernel.json
{"display_name":"IHaskell","argv":["/Users/bussonniermatthias/.cabal/bin/IHaskell" ,"kernel", "{connection_file}"]}
```

And it should work with IPython 3.0.


Side note, conceal extension is quite cool.

got a kernel crash with `\.<tab>`
```
[I 14:55:55.516 NotebookApp] Saving file at /Untitled.ipynb
IHaskell: src/IHaskell/IPython/Message/Parser.hs:(125,3)-(129,59): Irrefutable pattern failed for pattern Data.Aeson.Types.Internal.Success parsed
```

You can easily reproduce programatically with `IPython.notebook.kernel.complete('\.',2, function(data){console.log(data)})`

Should I open a separate bug ? 