### PR TITLE
Permit use of inline template haskell

### DIFF
--- a/ihaskell.cabal
+++ b/ihaskell.cabal
@@ -85,6 +85,7 @@ library
                        system-argv0         -any,
                        system-filepath      -any,
                        tar                  -any,
+                       template-haskell     -any, 
                        text                 >=0.11,
                        transformers         -any,
                        unix                 >= 2.6,

--- a/src/IHaskell/Eval/Evaluate.hs
+++ b/src/IHaskell/Eval/Evaluate.hs
@@ -699,7 +699,6 @@ evalCommand output (Expression expr) state = do
   -- typeclass instance, this will throw an exception and thus `attempt` will
   -- return False, and we just resort to plaintext.
   let displayExpr = printf "(IHaskell.Display.display (%s))" expr :: String
-  write displayExpr 
   canRunDisplay <- attempt $ exprType displayExpr
 
   -- Check if this is a widget.


### PR DESCRIPTION
Addresses Github issues: https://github.com/gibiansky/IHaskell/issues/236  , https://github.com/gibiansky/IHaskell/issues/183


To verify functionality, paste the following into a code block in
IHaskell.

```
:ext TemplateHaskell
import Language.Haskell.TH
import Control.Lens
data Foo a = Foo { _bar :: Int, _baz :: Int, _quux :: a }
makeLenses ''Foo
:ty baz
```