### PR TITLE
Adding TH to Cabal's test-suite requires

### DIFF
--- a/ihaskell.cabal
+++ b/ihaskell.cabal
@@ -169,6 +169,7 @@ Test-Suite hspec
                        haskell-src-exts     ==1.16.*,
                        hspec                -any,
                        HUnit                -any,
+                       template-haskell     -any,
                        MissingH             >=1.2,
                        mtl                  >=2.1,
                        parsec               -any,


### PR DESCRIPTION
Seems that TH needs to be listed in the Cabal file for the test-suite to run.