### PR TITLE
Ignoring > in front of code lines

### DIFF
--- a/src/IHaskell/Eval/Evaluate.hs
+++ b/src/IHaskell/Eval/Evaluate.hs
@@ -230,9 +230,10 @@ data EvalOut = EvalOut {
   }
 
 cleanString :: String -> String
-cleanString x = strip $ if allBrackets then clean else x
+cleanString x =  if allBrackets then clean else str
   where
-    l = lines x
+    str = strip x
+    l = lines str
     allBrackets = all (fAny [isPrefixOf ">", null]) l
     fAny fs x = any ($x) fs
     clean = unlines $ map removeBracket l

--- a/src/IHaskell/Eval/Evaluate.hs
+++ b/src/IHaskell/Eval/Evaluate.hs
@@ -237,7 +237,7 @@ cleanString x =  if allBrackets then clean else str
     allBrackets = all (fAny [isPrefixOf ">", null]) l
     fAny fs x = any ($x) fs
     clean = unlines $ map removeBracket l
-    removeBracket (x:xs) = xs
+    removeBracket ('>':xs) = xs
     removeBracket [] = []
     -- should never happen:
     removeBracket other = error $ "Expected bracket as first char, but got string: " ++ other 

--- a/src/IHaskell/Eval/Evaluate.hs
+++ b/src/IHaskell/Eval/Evaluate.hs
@@ -233,11 +233,13 @@ cleanString :: String -> String
 cleanString x = strip $ if allBrackets then clean else x
   where
     l = lines x
-    allBrackets = all (fAny [isInfixOf ">", null]) l
+    allBrackets = all (fAny [isPrefixOf ">", null]) l
     fAny fs x = any ($x) fs
     clean = unlines $ map removeBracket l
     removeBracket (x:xs) = xs
     removeBracket [] = []
+    -- should never happen:
+    removeBracket other = error $ "Expected bracket as first char, but got string: " ++ other 
 
 -- | Evaluate some IPython input code.
 evaluate :: KernelState                  -- ^ The kernel state.

--- a/src/IHaskell/Eval/Evaluate.hs
+++ b/src/IHaskell/Eval/Evaluate.hs
@@ -229,13 +229,23 @@ data EvalOut = EvalOut {
     evalComms :: [CommInfo]
   }
 
+cleanString :: String -> String
+cleanString x = strip $ if allBrackets then clean else x
+  where
+    l = lines x
+    allBrackets = all (fAny [isInfixOf ">", null]) l
+    fAny fs x = any ($x) fs
+    clean = unlines $ map removeBracket l
+    removeBracket (x:xs) = xs
+    removeBracket [] = []
+
 -- | Evaluate some IPython input code.
 evaluate :: KernelState                  -- ^ The kernel state.
          -> String                       -- ^ Haskell code or other interpreter commands.
          -> (EvaluationResult -> IO ())   -- ^ Function used to publish data outputs.
          -> Interpreter KernelState
 evaluate kernelState code output = do
-  cmds <- parseString (strip code)
+  cmds <- parseString (cleanString code)
   let execCount = getExecutionCounter kernelState
 
   when (getLintStatus kernelState /= LintOff) $ liftIO $ do


### PR DESCRIPTION
Ignores all > at the beginning of lines, which makes it easier to copy and paste code from literate Haskell files (like this: https://github.com/VinylRecords/Vinyl/blob/master/tests/Intro.lhs). 

Don't think > can ever occur in Haskell code at the beginning of a line, so it should be safe.