### PR TITLE
Eval.Util: Define FlagSpec type synonym

### DIFF
--- a/src/IHaskell/Eval/Util.hs
+++ b/src/IHaskell/Eval/Util.hs
@@ -78,7 +78,12 @@ extensionFlag ext =
     flagMatchesNo ext (name, _, _) = ext == "No" ++ name
 
 #if !MIN_VERSION_ghc(7,10,0)
+type FlagSpec flag = (String, flag, Bool -> EwM (CmdLineP DynFlags) ())
+
+flagSpecName :: FlagSpec a -> String
 flagSpecName (name,_,_) = name
+
+flagSpecFlag :: FlagSpec a -> a
 flagSpecFlag (_,flag,_) = flag
 #endif
 


### PR DESCRIPTION
Apparently this wasn't exported pre-7.10.

Properly fixes breakage reported in #380 due to #375. 