### PR TITLE
Adding pretty-show by default

### DIFF
--- a/ihaskell.cabal
+++ b/ihaskell.cabal
@@ -76,6 +76,7 @@ library
                        MissingH             >=1.2,
                        mtl                  >=2.1,
                        parsec               -any,
+                       pretty-show          -any,
                        process              >=1.1,
                        random               >=1.0,
                        shelly               >=1.5,

--- a/src/IHaskell/Eval/Util.hs
+++ b/src/IHaskell/Eval/Util.hs
@@ -19,7 +19,8 @@ module IHaskell.Eval.Util (
   -- * Pretty printing
   doc,
   pprDynFlags,
-  pprLanguages
+  pprLanguages,
+  prettyShow
   ) where
 
 import           ClassyPrelude hiding ((<>))
@@ -48,6 +49,7 @@ import           Control.Monad (void)
 import           Data.Function (on)
 import           Data.String.Utils (replace)
 import           Data.List (nubBy)
+import           Text.Show.Pretty
 
 -- | A extension flag that can be set or unset.
 data ExtFlag
@@ -234,6 +236,23 @@ initGhci sandboxPackages = do
                                        ghcLink = LinkInMemory,
                                        pprCols = 300,
                                        extraPkgConfs = pkgConfs }
+
+  installInteractivePrint
+
+-- Reconfigurable pretty-printing Ticket #5461
+prettyShow :: Show a => a -> IO ()
+prettyShow x = putStrLn $ pack $ Text.Show.Pretty.ppShow x
+
+installInteractivePrint :: GhcMonad m => m ()
+installInteractivePrint = do
+  importDecl <- parseImportDecl "import qualified IHaskell.Eval.Util"
+  let pretty = importDecl { ideclImplicit = True }
+  imports <- getContext
+  setContext $ IIDecl pretty : imports
+
+  (name:_) <- GHC.parseName "IHaskell.Eval.Util.prettyShow"
+  modifySession (\he -> let new_ic = setInteractivePrintName (hsc_IC he) name
+                        in he{hsc_IC = new_ic})
 
 -- | Evaluate a single import statement.
 -- If this import statement is importing a module which was previously


### PR DESCRIPTION
![screen shot 2015-02-26 at 10 10 09](https://cloud.githubusercontent.com/assets/61575/6394577/6578bf1e-bda0-11e4-9c67-5ecef34c0ce5.png)

Making Text.Show.Pretty the default Show method. (An alternative would be to make it optional, but then ':set -InteractiveShow' needs to be implemented, currently ghci doesn't pick it up when used in IHaskell, even if it gives no error)