### PR TITLE
Removing unused imports, fixing other -fwarn issues

### DIFF
--- a/src/IHaskell/Eval/Parser.hs
+++ b/src/IHaskell/Eval/Parser.hs
@@ -14,8 +14,7 @@ module IHaskell.Eval.Parser (
     PragmaType(..),
     ) where
 
--- Hide 'unlines' to use our own 'joinLines' instead.
-import ClassyPrelude hiding (head, liftIO, unlines, maximumBy)
+import ClassyPrelude hiding (head, liftIO, maximumBy)
 
 import Data.List (maximumBy, inits)
 import Data.String.Utils (startswith, strip, split)

--- a/src/IHaskell/Eval/Parser.hs
+++ b/src/IHaskell/Eval/Parser.hs
@@ -15,24 +15,14 @@ module IHaskell.Eval.Parser (
     ) where
 
 -- Hide 'unlines' to use our own 'joinLines' instead.
-import ClassyPrelude hiding (head, tail, liftIO, unlines, maximumBy)
+import ClassyPrelude hiding (head, liftIO, unlines, maximumBy)
 
-import Data.List (findIndex, maximumBy, maximum, inits)
+import Data.List (maximumBy, inits)
 import Data.String.Utils (startswith, strip, split)
-import Data.List.Utils (subIndex)
-import Prelude (init, last, head, tail)
+import Prelude (head, tail)
 import Control.Monad (msum)
 
-import Bag
-import ErrUtils hiding (ErrMsg)
-import FastString
 import GHC hiding (Located)
-import GhcMonad
-import Lexer
-import OrdList
-import Outputable hiding ((<>))
-import SrcLoc hiding (Located)
-import StringBuffer
 
 import Language.Haskell.GHC.Parser
 import IHaskell.Eval.Util
@@ -93,8 +83,9 @@ parseString codeString = do
       -- Return to previous flags. When parsing, flags can be set to make
       -- sure parsing works properly. But we don't want those flags to be
       -- set during evaluation until the right time.
-      setSessionDynFlags flags
+      _ <- setSessionDynFlags flags
       return result
+    otherwise -> error "parseString failed, output was neither Parsed nor Failure"
   where
     parseChunk :: GhcMonad m => String -> LineNumber -> m (Located CodeBlock)
     parseChunk chunk line = Located line <$> handleChunk chunk line
@@ -123,10 +114,6 @@ parseString codeString = do
     -- Test if a chunk is a pragma.
     isPragma :: String -> Bool
     isPragma = startswith "{-#" . strip
-
-    -- Number of lines in this string.
-    nlines :: String -> Int
-    nlines = length . lines
 
 activateExtensions :: GhcMonad m => CodeBlock -> m ()
 activateExtensions (Directive SetExtension ext) = void $ setExtension ext
@@ -193,6 +180,7 @@ parseCodeChunk code startLine = do
     tryParser string (blockType, parser) = case parser string of
       Parsed res -> Parsed (blockType res)
       Failure err loc -> Failure err loc
+      otherwise -> error "tryParser failed, output was neither Parsed nor Failure"
 
     parsers :: DynFlags -> [(String -> CodeBlock, String -> ParseOutput String)]
     parsers flags =
@@ -297,7 +285,4 @@ getModuleName moduleSrc = do
       case unLoc <$> hsmodName (unLoc mod) of
         Nothing -> error "Module must have a name."
         Just name -> return $ split "." $ moduleNameString name
-
--- Not the same as 'unlines', due to trailing \n
-joinLines :: [String] -> String
-joinLines = intercalate "\n"
+    otherwise -> error "getModuleName failed, output was neither Parsed nor Failure"


### PR DESCRIPTION
Seems to be a bunch of left-over imports and unused functions in Parser.hs. Still compiles cleanly after taking all this out. Not sure if this kind of pull-request is welcome? I think it makes it easier to navigate the source for others if all the imports are used, etc.