### PR TITLE
On MacOS, build.sh installs arithmoi without llvm

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -57,7 +57,12 @@ done
 
 # Stick a "./" before everything.
 INSTALL_DIRS=`echo $INSTALLS | tr ' ' '\n' | sed 's#^#./#' | tr ' ' '\n'`
-cabal install -j $INSTALL_DIRS --force-reinstalls
+
+if [ `uname` = Darwin ]; then
+  cabal install --constraint "arithmoi -llvm" -j $INSTALL_DIRS --force-reinstalls
+else
+  cabal install -j $INSTALL_DIRS --force-reinstalls
+fi
 
 # Finish installing ihaskell-diagrams.
 if [ $# -gt 0 ]; then


### PR DESCRIPTION
Add constraint on cabal install for MacOS to not use LLVM for arithmoi, addressing a known problem:

https://bitbucket.org/dafis/arithmoi/issue/15/fails-to-compile-with-ghc-784-due-to-fllvm

http://stackoverflow.com/questions/24796874/cant-install-diagrams-arithmoi-on-mac