### PR TITLE
Linux install prerequisites.

### DIFF
--- a/linux-install.sh
+++ b/linux-install.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Installation for Linux (tested on Ubuntu 14.10)
+
+sudo apt-get install python-dev
+sudo apt-get install python-pip
+sudo pip install -U 'ipython[all]'
+
+sudo apt-get install libtinfo-dev
+sudo apt-get install libzmq3-dev
+
+sudo apt-get install libcairo2-dev
+sudo apt-get install libpango1.0-dev
+
+./build.sh all
+./build.sh display


### PR DESCRIPTION
This is a script I wrote that installs everything on Ubuntu 14.10 Linux. It seems `libzmq3-dev` seems to suffice, without the need to clone the ZeroMQ repo as the README currently instructs and as `.travis.yml` currently does.

https://github.com/gibiansky/IHaskell/issues/410