### PR TITLE
Improve Mac, Linux installation scripts. Still assumes using build.sh.

### DIFF
--- a/linux-install.sh
+++ b/linux-install.sh
@@ -1,16 +1,38 @@
 #!/bin/sh
 
-# Installation for Linux (tested on Ubuntu 14.10)
+# Installation for Linux (tested on Ubuntu 14.10) from IHaskell repo directory.
+# TODO Split out setup for installation from Hackage released versions.
 
-sudo apt-get install python-dev
-sudo apt-get install python-pip
-sudo pip install -U 'ipython[all]'
+# Install IPython.
+# python-pip is out of date, causes problems, so we get the latest version.
+#sudo apt-get install python-pip
+easy_install -U pip
+pip install -U 'ipython[all]'
 
-sudo apt-get install libtinfo-dev
-sudo apt-get install libzmq3-dev
+# Install GHC, Cabal, Alex, Happy
 
-sudo apt-get install libcairo2-dev
-sudo apt-get install libpango1.0-dev
+# Adjust these as you desire.
+CABALVER=1.22
+GHCVER=7.8.4
+# You will want to add this to your shell startup to pick up
+# what gets installed by Cabal.
+export PATH=~/.cabal/bin:/opt/cabal/$CABALVER/bin:/opt/ghc/$GHCVER/bin:$PATH
+
+sudo apt-get update
+sudo apt-get install -y software-properties-common
+sudo add-apt-repository -y ppa:hvr/ghc
+sudo apt-get update
+sudo apt-get install -y cabal-install-$CABALVER ghc-$GHCVER
+
+cabal install alex happy
+
+sudo apt-get install -y python-dev
+
+sudo apt-get install -y libtinfo-dev
+sudo apt-get install -y libzmq3-dev
+
+sudo apt-get install -y libcairo2-dev
+sudo apt-get install -y libpango1.0-dev
 
 ./build.sh all
 ./build.sh display

--- a/linux-install.sh
+++ b/linux-install.sh
@@ -40,4 +40,3 @@ sudo apt-get install -y libcairo2-dev
 sudo apt-get install -y libpango1.0-dev
 
 ./build.sh all
-./build.sh display

--- a/linux-install.sh
+++ b/linux-install.sh
@@ -3,31 +3,36 @@
 # Installation for Linux (tested on Ubuntu 14.10) from IHaskell repo directory.
 # TODO Split out setup for installation from Hackage released versions.
 
+ghc --version >& /dev/null
+if [ $? ]; then
+    true
+else
+    echo "Please install ghc."
+fi
+
+cabal --version >& /dev/null
+if [ $? ]; then
+    true
+else
+    echo "Please install Cabal."
+fi
+
 # Install IPython.
-# python-pip is out of date, causes problems, so we get the latest version.
+# python-pip is out of date, causes problems, so we get the latest version
+# using easy_install instead.
 #sudo apt-get install python-pip
+sudo apt-get install -y python-dev
+
 easy_install -U pip
 pip install -U 'ipython[all]'
 
-# Install GHC, Cabal, Alex, Happy
+# Make sure to have basic tools installed.
+cabal update
+cabal install happy alex
+cabal install cpphs
+cabal install gtk2hs-buildtools
 
-# Adjust these as you desire.
-CABALVER=1.22
-GHCVER=7.8.4
-# You will want to add this to your shell startup to pick up
-# what gets installed by Cabal.
-export PATH=~/.cabal/bin:/opt/cabal/$CABALVER/bin:/opt/ghc/$GHCVER/bin:$PATH
-
-sudo apt-get update
-sudo apt-get install -y software-properties-common
-sudo add-apt-repository -y ppa:hvr/ghc
-sudo apt-get update
-sudo apt-get install -y cabal-install-$CABALVER ghc-$GHCVER
-
-cabal install alex happy
-
-sudo apt-get install -y python-dev
-
+# C libraries
 sudo apt-get install -y libtinfo-dev
 sudo apt-get install -y libzmq3-dev
 

--- a/macos-install.sh
+++ b/macos-install.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-# Installation for Mac OS X.
+# Installation for Mac OS X from IHaskell repo directory.
+# TODO Split out setup for installation from Hackage released versions.
 #
 # This script assumes use of Homebrew.
 # It is assumed you already have GHC and Cabal installed through Homebrew
@@ -16,6 +17,19 @@ if [ $? ]; then
 else
     echo "Homebrew needs to be installed."
     echo "  Download from http://brew.sh/"
+    exit 1
+fi
+
+brew update
+
+# Install IPython.
+pip --version >& /dev/null
+if [ $? ]; then
+    pip install -U 'ipython[all]'
+else
+    echo "Python pip needs to be installed."
+    echo "  One way is to install Homebrew Python:"
+    echo "  $ brew install python"
     exit 1
 fi
 
@@ -36,7 +50,7 @@ cabal --version >& /dev/null
 if [ $? ]; then
     true
 else
-    echo "Please install ghc."
+    echo "Please install Cabal."
     echo "  $ brew install cabal-install"
 fi
 

--- a/macos-install.sh
+++ b/macos-install.sh
@@ -76,4 +76,3 @@ brew install pango
 export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/opt/X11/lib/pkgconfig
 
 ./build.sh all
-./build.sh display


### PR DESCRIPTION
Linux: rid using `python-pip` since it eventually caused an insidious problem: http://stackoverflow.com/questions/27341064/how-do-i-fix-importerror-cannot-import-name-incompleteread 

Mac: add installation of IPython.