### PR TITLE
Simplified cmdline interface

### DIFF
--- a/Hspec.hs
+++ b/Hspec.hs
@@ -89,7 +89,24 @@ becomes string expected = evaluationComparing comparison string
 pages string expected = evaluationComparing comparison string
   where
     comparison (results, pageOut) =
-      strip pageOut `shouldBe` strip (unlines expected)
+      strip (stripHtml pageOut) `shouldBe` strip (unlines expected)
+
+    -- A very, very hacky method for removing HTML
+    stripHtml str = go str
+      where
+        go ('<':str) = case stripPrefix "script" str of
+          Nothing -> go' str
+          Just str -> dropScriptTag str
+        go (x:xs) = x : go xs
+        go [] = []
+
+        go' ('>':str) = go str
+        go' (x:xs) = go' xs
+        go' [] = error $ "Unending bracket html tag in string " ++ str
+
+        dropScriptTag str = case stripPrefix "</script>" str of
+          Just str -> go str
+          Nothing -> dropScriptTag $ tail str
 
 readCompletePrompt :: String -> (String, Int)
 -- | @readCompletePrompt "xs*ys"@ return @(xs, i)@ where i is the location of

--- a/build.sh
+++ b/build.sh
@@ -2,16 +2,16 @@
 set -e
 
 print_help () {
-  echo "Run build.sh from inside the IHaskell directory to install packages in this repository:"
-  echo "  ./build.sh ihaskell # Install IHaskell and its dependencies"
-  echo "  ./build.sh quick    # Install IHaskell, but not its dependencies"
-  echo "  ./build.sh all      # Install IHaskell, dependencies, and all display packages"
-  echo "  ./build.sh display  # Install IHaskell and display libraries"
+  echo "Run build.sh from inside the ihaskell directory to install packages in this repository:"
+  echo "  ./build.sh ihaskell # Install ihaskell and its dependencies"
+  echo "  ./build.sh quick    # Install ihaskell, but not its dependencies"
+  echo "  ./build.sh all      # Install ihaskell, dependencies, and all display packages"
+  echo "  ./build.sh display  # Install ihaskell and display libraries"
   echo
-  echo "If this is your first time installing IHaskell, run './build.sh ihaskell'."
+  echo "If this is your first time installing ihaskell, run './build.sh ihaskell'."
 }
 
-# Verify that we're in the IHaskell directory.
+# Verify that we're in the ihaskell directory.
 if [ ! -e ihaskell.cabal ]; then
   print_help;
   exit 1

--- a/ihaskell.cabal
+++ b/ihaskell.cabal
@@ -68,6 +68,7 @@ library
                        filepath             -any,
                        ghc                  >=7.6 || < 7.11,
                        ghc-parser           >=0.1.4,
+                       ghc-paths            ==0.1.*,
                        haskeline            -any,
                        here                 ==1.2.*,
                        hlint                >=1.9 && <2.0,
@@ -120,18 +121,15 @@ library
 --  other-modules: 
 --                   Paths_ihaskell
 
-executable IHaskell
+executable ihaskell
   -- .hs or .lhs file containing the Main module.
   main-is:             src/Main.hs
   ghc-options: -threaded
-
-  default-extensions: DoAndIfThenElse
   
   -- Other library packages from which modules are imported.
   default-language:    Haskell2010
   build-depends:       
                        base                 >=4.6 && < 4.9,
-                       ghc-paths            ==0.1.*,
                        aeson                >=0.6 && < 0.9,
                        bytestring           >=0.10,
                        cereal               >=0.3,

--- a/src/IHaskell/Eval/Evaluate.hs
+++ b/src/IHaskell/Eval/Evaluate.hs
@@ -686,9 +686,8 @@ evalCommand _ (Directive GetInfo str) state = safely state $ do
   -- Get all the info for all the names we're given.
   strings <- getDescription str
 
-  let output = case getFrontend state of
-        IPythonConsole -> unlines strings
-        IPythonNotebook -> unlines (map htmlify strings)
+  -- TODO: Make pager work without html by porting to newer architecture
+  let output = unlines (map htmlify strings)
       htmlify str =
         printf "<div style='background: rgb(247, 247, 247);'><form><textarea id='code'>%s</textarea></form></div>" str
         ++ script
@@ -980,10 +979,8 @@ hoogleResults state results = EvalOut {
     evalComms = []
   }
   where
-    fmt =
-        case getFrontend state of
-          IPythonNotebook -> Hoogle.HTML
-          IPythonConsole -> Hoogle.Plain
+    -- TODO: Make pager work with plaintext
+    fmt = Hoogle.HTML
     output = unlines $ map (Hoogle.render fmt) results
 
 -- Read from a file handle until we hit a delimiter or until we've read

--- a/src/IHaskell/Flags.hs
+++ b/src/IHaskell/Flags.hs
@@ -5,7 +5,6 @@ module IHaskell.Flags (
     Args(..),
     LhsStyle(..),
     lhsStyleBird,
-    NotebookFormat(..),
     parseFlags,
     help,
     ) where
@@ -21,18 +20,12 @@ import           IHaskell.Types
 data Args = Args IHaskellMode [Argument]
   deriving Show
 
-data Argument = ServeFrom String    -- ^ Which directory to serve notebooks from.
-              | Extension String    -- ^ An extension to load at startup.
-              | ConfFile String     -- ^ A file with commands to load at startup.
+data Argument = ConfFile String     -- ^ A file with commands to load at startup.
               | OverwriteFiles      -- ^ Present when output should overwrite existing files. 
-              | ConvertFrom String
-              | ConvertTo String
-              | ConvertFromFormat NotebookFormat
-              | ConvertToFormat NotebookFormat
-              | ConvertLhsStyle (LhsStyle String)
               | GhcLibDir String    -- ^ Where to find the GHC libraries.
               | KernelDebug         -- ^ Spew debugging output from the kernel.
               | Help                -- ^ Display help text.
+              | ConvertLhsStyle (LhsStyle String)
   deriving (Eq, Show)
 
 data LhsStyle string = LhsStyle { lhsCodePrefix :: string  -- ^ @>@
@@ -44,19 +37,12 @@ data LhsStyle string = LhsStyle { lhsCodePrefix :: string  -- ^ @>@
                                 }
   deriving (Eq, Functor, Show)
 
-data NotebookFormat = LhsMarkdown
-                    | IpynbFile
-  deriving (Eq, Show)
-
 -- Which mode IHaskell is being invoked in.
 -- `None` means no mode was specified.
 data IHaskellMode = ShowHelp String
                   | InstallKernelSpec
-                  | Notebook
-                  | Console
                   | ConvertLhs
                   | Kernel (Maybe String)
-                  | View (Maybe ViewFormat) (Maybe String)
   deriving (Eq, Show)
 
 -- | Given a list of command-line arguments, return the IHaskell mode and
@@ -97,34 +83,27 @@ ghcLibFlag = flagReq ["ghclib", "l"] (store GhcLibDir) "<path>" "Library directo
 
 kernelDebugFlag :: Flag Args
 kernelDebugFlag = flagNone ["debug"] addDebug "Print debugging output from the kernel."
-  where addDebug (Args mode prev) = Args mode (KernelDebug : prev)
-
-universalFlags :: [Flag Args]
-universalFlags = [ flagReq ["extension", "e", "X"] (store Extension) "<ghc-extension>"
-                     "Extension to enable at start."
-                 , flagReq ["conf", "c"] (store ConfFile) "<rc.hs>"
-                     "File with commands to execute at start; replaces ~/.ihaskell/rc.hs."
-                 , flagHelpSimple (add Help)
-                 ]
   where
-    add flag (Args mode flags) = Args mode $ flag : flags
+    addDebug (Args mode prev) = Args mode (KernelDebug : prev)
+
+confFlag :: Flag Args
+confFlag = flagReq ["conf", "c"] (store ConfFile) "<rc.hs>"
+             "File with commands to execute at start; replaces ~/.ihaskell/rc.hs."
+
+helpFlag = flagHelpSimple (add Help)
+
+add flag (Args mode flags) = Args mode $ flag : flags
 
 store :: (String -> Argument) -> String -> Args -> Either String Args
 store constructor str (Args mode prev) = Right $ Args mode $ constructor str : prev
 
-notebook :: Mode Args
-notebook = mode "notebook" (Args Notebook []) "Browser-based notebook interface." noArgs $
-  flagReq ["serve","s"] (store ServeFrom) "<dir>" "Directory to serve notebooks from.":
-  universalFlags
-
-console :: Mode Args
-console = mode "console" (Args Console []) "Console-based interactive repl." noArgs universalFlags
-
 installKernelSpec :: Mode Args
-installKernelSpec = mode "install" (Args InstallKernelSpec []) "Install the Jupyter kernelspec." noArgs []
+installKernelSpec =
+  mode "install" (Args InstallKernelSpec []) "Install the Jupyter kernelspec." noArgs
+    [ghcLibFlag, kernelDebugFlag, confFlag, helpFlag]
 
 kernel :: Mode Args
-kernel = mode "kernel" (Args (Kernel Nothing) []) "Invoke the IHaskell kernel." kernelArg [ghcLibFlag, kernelDebugFlag]
+kernel = mode "kernel" (Args (Kernel Nothing) []) "Invoke the IHaskell kernel." kernelArg []
   where
     kernelArg = flagArg update "<json-kernel-file>"
     update filename (Args _ flags) = Right $ Args (Kernel $ Just filename) flags
@@ -133,37 +112,35 @@ convert :: Mode Args
 convert = mode "convert" (Args ConvertLhs []) description unnamedArg convertFlags
   where
     description = "Convert between Literate Haskell (*.lhs) and Ipython notebooks (*.ipynb)."
-    convertFlags = universalFlags ++ [ flagReq ["input", "i"] (store ConvertFrom) "<file>"
-                                         "File to read."
-                                     , flagReq ["output", "o"] (store ConvertTo) "<file>"
-                                         "File to write."
-                                     , flagReq ["from", "f"] (storeFormat ConvertFromFormat)
-                                         "lhs|ipynb" "Format of the file to read."
-                                     , flagReq ["to", "t"] (storeFormat ConvertToFormat) "lhs|ipynb"
-                                         "Format of the file to write."
-                                     , flagNone ["force"] consForce
-                                         "Overwrite existing files with output."
-                                     , flagReq ["style", "s"] storeLhs "bird|tex"
-                                         "Type of markup used for the literate haskell file"
-                                     , flagNone ["bird"] (consStyle lhsStyleBird)
-                                         "Literate haskell uses >"
-                                     , flagNone ["tex"] (consStyle lhsStyleTex)
-                                         "Literate haskell uses \\begin{code}"
-                                     ]
+    convertFlags = [ flagReq ["input", "i"] (store ConvertFrom) "<file>" "File to read."
+                   , flagReq ["output", "o"] (store ConvertTo) "<file>" "File to write."
+                   , flagReq ["from", "f"] (storeFormat ConvertFromFormat) "lhs|ipynb"
+                       "Format of the file to read."
+                   , flagReq ["to", "t"] (storeFormat ConvertToFormat) "lhs|ipynb"
+                       "Format of the file to write."
+                   , flagNone ["force"] consForce "Overwrite existing files with output."
+                   , flagReq ["style", "s"] storeLhs "bird|tex"
+                       "Type of markup used for the literate haskell file"
+                   , flagNone ["bird"] (consStyle lhsStyleBird) "Literate haskell uses >"
+                   , flagNone ["tex"] (consStyle lhsStyleTex) "Literate haskell uses \\begin{code}"
+                   , helpFlag
+                   ]
 
     consForce (Args mode prev) = Args mode (OverwriteFiles : prev)
     unnamedArg = Arg (store ConvertFrom) "<file>" False
     consStyle style (Args mode prev) = Args mode (ConvertLhsStyle style : prev)
 
-    storeFormat constructor str (Args mode prev) = case toLower str of
-      "lhs" -> Right $ Args mode $ constructor LhsMarkdown : prev
-      "ipynb" -> Right $ Args mode $ constructor IpynbFile : prev
-      _ -> Left $ "Unknown format requested: " ++ str
+    storeFormat constructor str (Args mode prev) =
+      case toLower str of
+        "lhs"   -> Right $ Args mode $ constructor LhsMarkdown : prev
+        "ipynb" -> Right $ Args mode $ constructor IpynbFile : prev
+        _       -> Left $ "Unknown format requested: " ++ str
 
-    storeLhs str previousArgs = case toLower str of
-      "bird" -> success lhsStyleBird
-      "tex"  -> success lhsStyleTex
-      _      -> Left $ "Unknown lhs style: " ++ str
+    storeLhs str previousArgs =
+      case toLower str of
+        "bird" -> success lhsStyleBird
+        "tex"  -> success lhsStyleTex
+        _      -> Left $ "Unknown lhs style: " ++ str
       where
         success lhsStyle = Right $ consStyle lhsStyle previousArgs
 
@@ -171,39 +148,6 @@ lhsStyleBird, lhsStyleTex :: LhsStyle String
 lhsStyleBird = LhsStyle "> " "\n<< " "" "" "" ""
 lhsStyleTex  = LhsStyle "" "" "\\begin{code}" "\\end{code}" "\\begin{verbatim}" "\\end{verbatim}"
 
-
-view :: Mode Args
-view =
-  let empty = mode "view" (Args (View Nothing Nothing) []) "View IHaskell notebook." noArgs flags in
-    empty {
-      modeNames = ["view"],
-      modeCheck  =
-        \a@(Args (View fmt file) _) ->
-          if not (isJust fmt && isJust file)
-          then Left "Syntax: IHaskell view <format> <name>[.ipynb]"
-          else Right a,
-      modeHelp = concat [
-        "Convert an IHaskell notebook to another format.\n",
-        "Notebooks are searched in the IHaskell directory and the current directory.\n",
-        "Available formats are " ++ intercalate ", " (map show 
-          ["pdf", "html", "ipynb", "markdown", "latex"]),
-        "."
-      ],
-      modeArgs = ([formatArg, filenameArg] ++ fst (modeArgs empty),
-                  snd $ modeArgs empty)
-                                                    
-  }
-  where
-    flags = [flagHelpSimple (add Help)]
-    formatArg = flagArg updateFmt "<format>"
-    filenameArg = flagArg updateFile "<name>[.ipynb]"
-    updateFmt fmtStr (Args (View _ s) flags) = 
-      case readMay fmtStr of
-        Just fmt -> Right $ Args (View (Just fmt) s) flags
-        Nothing -> Left $ "Invalid format '" ++ fmtStr ++ "'."
-    updateFile name (Args (View f _) flags) = Right $ Args (View f (Just name)) flags
-    add flag (Args mode flags) = Args mode $ flag : flags
-  
 ihaskellArgs :: Mode Args
 ihaskellArgs =
   let descr = "Haskell for Interactive Computing." 

--- a/src/IHaskell/Flags.hs
+++ b/src/IHaskell/Flags.hs
@@ -4,6 +4,7 @@ module IHaskell.Flags (
     Argument(..),
     Args(..),
     LhsStyle(..),
+    NotebookFormat(..),
     lhsStyleBird,
     parseFlags,
     help,
@@ -25,6 +26,10 @@ data Argument = ConfFile String     -- ^ A file with commands to load at startup
               | GhcLibDir String    -- ^ Where to find the GHC libraries.
               | KernelDebug         -- ^ Spew debugging output from the kernel.
               | Help                -- ^ Display help text.
+              | ConvertFrom String
+              | ConvertTo String
+              | ConvertFromFormat NotebookFormat
+              | ConvertToFormat NotebookFormat
               | ConvertLhsStyle (LhsStyle String)
   deriving (Eq, Show)
 
@@ -36,6 +41,11 @@ data LhsStyle string = LhsStyle { lhsCodePrefix :: string  -- ^ @>@
                                 , lhsEndOutput :: string  -- ^ @\\end{verbatim}@
                                 }
   deriving (Eq, Functor, Show)
+
+
+data NotebookFormat = LhsMarkdown
+                    | IpynbFile
+  deriving (Eq, Show)
 
 -- Which mode IHaskell is being invoked in.
 -- `None` means no mode was specified.
@@ -66,15 +76,13 @@ parseFlags flags =
     modeFlags = concatMap modeNames allModes
 
 allModes :: [Mode Args]
-allModes = [installKernelSpec, console, notebook, view, kernel, convert]
+allModes = [installKernelSpec, kernel, convert]
 
 -- | Get help text for a given IHaskell ode.
 help :: IHaskellMode -> String
 help mode = showText (Wrap 100) $ helpText [] HelpFormatAll $ chooseMode mode
   where
-    chooseMode Console = console
     chooseMode InstallKernelSpec = installKernelSpec
-    chooseMode Notebook = notebook
     chooseMode (Kernel _) = kernel
     chooseMode ConvertLhs = convert
 

--- a/src/IHaskell/IPython.hs
+++ b/src/IHaskell/IPython.hs
@@ -232,9 +232,9 @@ getIHaskellPath = do
     -- variable to find where IHaskell lives.
     if FS.filename f == f
       then do
-        ihaskellPath <- which "IHaskell"
+        ihaskellPath <- which "ihaskell"
         case ihaskellPath of
-          Nothing   -> error "IHaskell not on $PATH and not referenced relative to directory."
+          Nothing   -> error "ihaskell not on $PATH and not referenced relative to directory."
           Just path -> return $ FS.encodeString path
       else do
         -- If it's actually a relative path, make it absolute.

--- a/src/IHaskell/Types.hs
+++ b/src/IHaskell/Types.hs
@@ -14,12 +14,9 @@ module IHaskell.Types (
   DisplayData(..),
   EvaluationResult(..),
   ExecuteReplyStatus(..),
-  InitInfo(..),
   KernelState(..),
   LintStatus(..),
   Width, Height,
-  FrontendType(..),
-  ViewFormat(..),
   Display(..),
   defaultKernelState,
   extractPlain,
@@ -32,45 +29,14 @@ module IHaskell.Types (
   KernelSpec(..),
   ) where
 
-import            ClassyPrelude
-import qualified  Data.ByteString.Char8           as Char
-import            Data.Serialize
-import            GHC.Generics
-import            Data.Map                        (Map, empty)
-import            Data.Aeson                      (Value)
+import           ClassyPrelude
+import qualified Data.ByteString.Char8 as Char
+import           Data.Serialize
+import           GHC.Generics
+import           Data.Map (Map, empty)
+import           Data.Aeson (Value)
 
-import            Text.Read                       as Read hiding (pfail, String)
-import            Text.ParserCombinators.ReadP
-
-import IHaskell.IPython.Kernel
-
-data ViewFormat
-     = Pdf
-     | Html
-     | Ipynb
-     | Markdown
-     | Latex
-     deriving Eq
-
-instance Show ViewFormat where
-  show Pdf         = "pdf"
-  show Html        = "html"
-  show Ipynb       = "ipynb"
-  show Markdown    = "markdown"
-  show Latex       = "latex"
-
-instance Read ViewFormat where
-  readPrec = Read.lift $ do
-    str <- munch (const True)
-    case str of
-      "pdf" -> return Pdf
-      "html" -> return Html
-      "ipynb" -> return Ipynb
-      "notebook" -> return Ipynb
-      "latex" -> return Latex
-      "markdown" -> return Markdown
-      "md" -> return Markdown
-      _ -> pfail
+import           IHaskell.IPython.Kernel
 
 -- | A class for displayable Haskell types.
 --
@@ -144,7 +110,6 @@ instance Semigroup Display where
 -- | All state stored in the kernel between executions.
 data KernelState = KernelState { getExecutionCounter :: Int
                                , getLintStatus :: LintStatus   -- Whether to use hlint, and what arguments to pass it. 
-                               , getFrontend :: FrontendType
                                , useSvg :: Bool
                                , useShowErrors :: Bool
                                , useShowTypes :: Bool
@@ -157,7 +122,6 @@ data KernelState = KernelState { getExecutionCounter :: Int
 defaultKernelState :: KernelState
 defaultKernelState = KernelState { getExecutionCounter = 1
                                  , getLintStatus = LintOn
-                                 , getFrontend = IPythonConsole
                                  , useSvg = True
                                  , useShowErrors = False
                                  , useShowTypes = False
@@ -165,11 +129,6 @@ defaultKernelState = KernelState { getExecutionCounter = 1
                                  , openComms = empty
                                  , kernelDebug = False
                                  }
-
-data FrontendType
-     = IPythonConsole
-     | IPythonNotebook
-     deriving (Show, Eq, Read)
 
 -- | Kernel options to be set via `:set` and `:option`.
 data KernelOpt = KernelOpt {
@@ -191,15 +150,6 @@ kernelOpts =
   , KernelOpt ["pager"]          []     $ \state -> state { usePager = True }
   , KernelOpt ["no-pager"]       []     $ \state -> state { usePager = False }
   ]
-
--- | Initialization information for the kernel.
-data InitInfo = InitInfo {
-  extensions :: [String],   -- ^ Extensions to enable at start.
-  initCells :: [String],    -- ^ Code blocks to run before start.
-  initDir :: String,        -- ^ Which directory this kernel should pretend to operate in.
-  frontend :: FrontendType  -- ^ What frontend this serves.
-  }
-  deriving (Show, Read)
 
 -- | Current HLint status.
 data LintStatus


### PR DESCRIPTION
This PR drastically simplifies the command line interface, limiting it only to three commands:
- `ihaskell kernel`: Used by the backend to run the kernel.
- `ihaskell convert`: Convert from and to LHS and IPYNB.
- `ihaskell install`: Install the IHaskell kernel. Any flags that are passed to `ihaskell install` are then passed along to `ihaskell kernel` through the kernelspec.

This also makes `IHaskell` into `ihaskell` to look just like `ipython`. This might break some other scripts, but hopefully the breakage isn't too bad.