### PR TITLE
Prevent kernel death on introspection.

### DIFF
--- a/ipython-kernel/src/IHaskell/IPython/EasyKernel.hs
+++ b/ipython-kernel/src/IHaskell/IPython/EasyKernel.hs
@@ -90,7 +90,7 @@ data KernelConfig m output result =
          , completion :: T.Text -> T.Text -> Int -> Maybe ([T.Text], T.Text, T.Text)
          -- | Return the information or documentation for its argument. The returned tuple consists of the
          -- name, the documentation, and the type, respectively.
-         , objectInfo :: T.Text -> Maybe (T.Text, T.Text, T.Text)
+         , inspectInfo :: T.Text -> Maybe (T.Text, T.Text, T.Text)
          -- | Execute a cell. The arguments are the contents of the cell, an IO action that will clear the
          -- current intermediate output, and an IO action that will add a new item to the intermediate
          -- output. The result consists of the actual result, the status to be sent to IPython, and the
@@ -228,25 +228,10 @@ replyTo config execCount interface req@ExecuteRequest { getCode = code } replyHe
 
 replyTo config _ _ req@CompleteRequest{} replyHeader =
   -- TODO: FIX
-  error "Unimplemented in IPython 3.0"
+  error "Completion: Unimplemented for IPython 3.0"
 
-replyTo config _ _ ObjectInfoRequest { objectName = obj } replyHeader =
-  return $
-    case objectInfo config obj of
-      Just (name, docs, ty) -> ObjectInfoReply
-        { header = replyHeader
-        , objectName = obj
-        , objectFound = True
-        , objectTypeString = ty
-        , objectDocString = docs
-        }
-      Nothing -> ObjectInfoReply
-        { header = replyHeader
-        , objectName = obj
-        , objectFound = False
-        , objectTypeString = ""
-        , objectDocString = ""
-        }
+replyTo _ _ _ InspectRequest{} _ = do
+  error $ "Inspection: Unimplemented for IPython 3.0"
 
 replyTo _ _ _ msg _ = do
   liftIO $ putStrLn "Unknown message: "

--- a/ipython-kernel/src/IHaskell/IPython/Message/Parser.hs
+++ b/ipython-kernel/src/IHaskell/IPython/Message/Parser.hs
@@ -74,7 +74,7 @@ parser :: MessageType            -- ^ The message type being parsed.
 parser KernelInfoRequestMessage = kernelInfoRequestParser
 parser ExecuteRequestMessage = executeRequestParser
 parser CompleteRequestMessage = completeRequestParser
-parser ObjectInfoRequestMessage = objectInfoRequestParser
+parser InspectRequestMessage = inspectRequestParser
 parser ShutdownRequestMessage = shutdownRequestParser
 parser InputReplyMessage = inputReplyParser
 parser CommOpenMessage = commOpenParser
@@ -139,11 +139,12 @@ completeRequestParser = requestParser $ \obj -> do
   pos <- obj .: "cursor_pos"
   return $ CompleteRequest noHeader code pos
 
-objectInfoRequestParser :: LByteString -> Message
-objectInfoRequestParser = requestParser $ \obj -> do
-  oname <- obj .: "oname"
+inspectRequestParser :: LByteString -> Message
+inspectRequestParser = requestParser $ \obj -> do
+  code <- obj .: "code"
+  pos <- obj .: "cursor_pos"
   dlevel <- obj .: "detail_level"
-  return $ ObjectInfoRequest noHeader oname dlevel
+  return $ InspectRequest noHeader code pos dlevel
 
 shutdownRequestParser :: LByteString -> Message
 shutdownRequestParser = requestParser $ \obj -> do

--- a/ipython-kernel/src/IHaskell/IPython/Message/Writer.hs
+++ b/ipython-kernel/src/IHaskell/IPython/Message/Writer.hs
@@ -65,15 +65,13 @@ instance ToJSON Message where
                       then string "ok"
                       else "error"
       ]
-  toJSON o@ObjectInfoReply{} =
+  toJSON i@InspectReply{} =
     object
-      [ "oname" .=
-        objectName o
-      , "found" .= objectFound o
-      , "ismagic" .= False
-      , "isalias" .= False
-      , "type_name" .= objectTypeString o
-      , "docstring" .= objectDocString o
+      [ "status" .= if inspectStatus i
+                      then string "ok"
+                      else "error"
+      , "data" .= object (map displayDataToJson . inspectData $ i)
+      , "metadata" .= object []
       ]
 
   toJSON ShutdownReply { restartPending = restart } =

--- a/src/IHaskell/Eval/Lint.hs
+++ b/src/IHaskell/Eval/Lint.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE NoImplicitPrelude, QuasiQuotes, ViewPatterns #-}
+{-# LANGUAGE FlexibleContexts, NoImplicitPrelude, QuasiQuotes, ViewPatterns #-}
 
 module IHaskell.Eval.Lint (lint) where
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -19,6 +19,7 @@ import           Text.Printf
 import           System.Posix.Signals
 import qualified Data.Map as Map
 import           Data.String.Here (hereFile)
+import qualified Data.Text as T
 
 -- IHaskell imports.
 import           IHaskell.Convert (convert)
@@ -334,17 +335,10 @@ replyTo _ req@CompleteRequest{} replyHeader state = do
       reply = CompleteReply replyHeader (map pack completions) start end Map.empty True
   return (state, reply)
 
--- Reply to the object_info_request message. Given an object name, return the associated type
--- calculated by GHC.
-replyTo _ ObjectInfoRequest { objectName = oname } replyHeader state = do
-  docs <- pack <$> info (unpack oname)
-  let reply = ObjectInfoReply
-        { header = replyHeader
-        , objectName = oname
-        , objectFound = strip docs /= ""
-        , objectTypeString = docs
-        , objectDocString = docs
-        }
+-- TODO: Implement inspect_reply
+replyTo _ InspectRequest{} replyHeader state = do
+  -- FIXME
+  let reply = InspectReply { header = replyHeader, inspectStatus = False, inspectData = [] }
   return (state, reply)
 
 -- TODO: Implement history_reply.


### PR DESCRIPTION
I have updated the code relating to introspection so that it now respects the messaging spec v5.0.
Still, there is no tooltip shown on the frontend, even though I was able to confirm (using `Debug.Trace`) that the message produced by `toJSON` (from `IHaskell.IPython.Message.Writer`) had proper structure.

I searched the ipython repository for keyword `tooltip`, and it seems like it is implemented in IPython but not in jupyter. We might have to implement custom tooltips for IHaskell.

This will be required for #347.