### PR TITLE
Split ubuntu-install.sh

### DIFF
--- a/root-deps.sh
+++ b/root-deps.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Script for installing ihaskell dependencies. Specifically, this script
+# installs dependencies using apt-get, and needs to be executed as root.
+
+# Directly utilized for providing ihaskell to jupyter/docker-demo-images
+
+if [ $(id -u) -ne 0 ]; then
+    echo "Please run as root"
+    exit 1
+fi
+
+if [ -z "$(which ghc)" ]; then
+    echo "Please install ghc."
+    exit 1
+fi
+
+if [ -z "$(which cabal)" ]; then
+    echo "Please install Cabal."
+    exit 1
+fi
+
+# If ipython is installed, and has a major version >= 3, then use the
+# installed version. Otherwise we install from scratch.
+if [ -n "$(which ipython)" ] && { [ $(ipython --version | tr '.' ' ' | cut -f 1 -d ' ') -ge 3 ]; } then
+    echo "Using ipython already installed: $(which ipython)"
+else
+    # Install IPython.
+    # python-pip is out of date, causes problems, so we get the latest version
+    # using easy_install instead.
+    #sudo apt-get install python-pip
+    apt-get install -y python-dev
+
+    # To get easy_install
+    apt-get install -y python-setuptools
+
+    easy_install -U pip
+
+    # -H to use .cache in /root
+    pip install -U 'ipython[all]'
+fi
+
+# C libraries
+apt-get install -y libtinfo-dev
+apt-get install -y libzmq3-dev
+
+apt-get install -y libcairo2-dev
+apt-get install -y libpango1.0-dev
+
+apt-get install -y libmagic-dev
+
+apt-get install -y libblas-dev
+apt-get install -y liblapack-dev

--- a/ubuntu-install.sh
+++ b/ubuntu-install.sh
@@ -1,37 +1,10 @@
 #!/bin/bash
 
-# Installation for Linux (tested on Ubuntu 14.10) from IHaskell repo directory.
+# Installation for Ubuntu Linux (tested on v14.10) from IHaskell repo directory.
 # TODO Split out setup for installation from Hackage released versions.
 
-if [ -z "$(which ghc)" ]; then
-    echo "Please install ghc."
-    exit 1
-fi
-
-if [ -z "$(which cabal)" ]; then
-    echo "Please install Cabal."
-    exit 1
-fi
-
-# If ipython is installed, and has a major version >= 3, then use the
-# installed version. Otherwise we install from scratch.
-if [ -n "$(which ipython)" ] && { [ $(ipython --version | tr '.' ' ' | cut -f 1 -d ' ') -ge 3 ]; } then
-    echo "Using ipython already installed:" "$(which ipython)"
-else
-    # Install IPython.
-    # python-pip is out of date, causes problems, so we get the latest version
-    # using easy_install instead.
-    #sudo apt-get install python-pip
-    sudo apt-get install -y python-dev
-
-    # To get easy_install
-    sudo apt-get install -y python-setuptools
-
-    sudo easy_install -U pip
-
-    # -H to use .cache in /root
-    sudo -H pip install -U 'ipython[all]'
-fi
+# Install the dependencies as root user
+sudo ./root-deps.sh
 
 # Make sure to have basic tools installed.
 cabal update
@@ -39,16 +12,5 @@ cabal install happy alex
 cabal install cpphs
 cabal install gtk2hs-buildtools
 
-# C libraries
-sudo apt-get install -y libtinfo-dev
-sudo apt-get install -y libzmq3-dev
-
-sudo apt-get install -y libcairo2-dev
-sudo apt-get install -y libpango1.0-dev
-
-sudo apt-get install -y libmagic-dev
-
-sudo apt-get install -y libblas-dev
-sudo apt-get install -y liblapack-dev
-
+# Build ihaskell, and all the display packages
 ./build.sh all


### PR DESCRIPTION
Required for adding `IHaskell` to try.jupyter.org.

Take a look at https://github.com/sumitsahrawat/docker-demo-images/commit/5941f5ecfe8f14ab68a54395e1e5720119f07565 for the usage it allows. Previously, docker had trouble with use of `sudo` in `ubuntu-install.sh`.

I tested the above by temporarily using my fork in the `Dockerfile`, and it looks great!