### PR TITLE
Update for #476, use CPP to manage different versions

### DIFF
--- a/ghc-parser/ghc-parser.cabal
+++ b/ghc-parser/ghc-parser.cabal
@@ -27,20 +27,14 @@ library
   build-tools:         happy, cpphs
   exposed-modules:     Language.Haskell.GHC.Parser,
                        Language.Haskell.GHC.HappyParser
-  -- other-modules:
+  other-modules:       Language.Haskell.GHC.HappyParser_760
+                     , Language.Haskell.GHC.HappyParser_782
+                     , Language.Haskell.GHC.HappyParser_783
+                     , Language.Haskell.GHC.HappyParser_710
   -- other-extensions:
   build-depends:       base                 >=4.6 && <4.9,
                        ghc                  >=7.6 && <7.11
 
-  if   impl(ghc >= 7.6) && impl(ghc < 7.8)
-    hs-source-dirs:      generic-src src-7.6
-  else
-    if impl(ghc >= 7.8) && impl(ghc < 7.8.3)
-      hs-source-dirs:    generic-src src-7.8.2
-    else
-      if impl(ghc < 7.10)
-        hs-source-dirs:    generic-src src-7.8.3
-      else
-        hs-source-dirs:    generic-src src-7.10
+  hs-source-dirs:      generic-src src
 
   default-language:    Haskell2010

--- a/ghc-parser/src/Language/Haskell/GHC/HappyParser.hs
+++ b/ghc-parser/src/Language/Haskell/GHC/HappyParser.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE CPP #-}
+
+module Language.Haskell.GHC.HappyParser
+ (
+#if __GLASGOW_HASKELL__ >= 760 && __GLASGOW_HASKELL__ < 780
+    module Language.Haskell.GHC.HappyParser_760
+#elif __GLASGOW_HASKELL__ >= 780 && __GLASGOW_HASKELL__ < 783
+    module Language.Haskell.GHC.HappyParser_782
+#elif __GLASGOW_HASKELL__ < 710
+    module Language.Haskell.GHC.HappyParser_783
+#else
+    module Language.Haskell.GHC.HappyParser_710
+#endif
+ )
+
+import Language.Haskell.GHC.HappyParser_760
+import Language.Haskell.GHC.HappyParser_782
+import Language.Haskell.GHC.HappyParser_783
+import Language.Haskell.GHC.HappyParser_710

--- a/ghc-parser/src/Language/Haskell/GHC/HappyParser_710.hs
+++ b/ghc-parser/src/Language/Haskell/GHC/HappyParser_710.hs
@@ -1,4 +1,4 @@
-module Language.Haskell.GHC.HappyParser
+module Language.Haskell.GHC.HappyParser_710
     ( fullStatement
     , fullImport
     , fullDeclaration

--- a/ghc-parser/src/Language/Haskell/GHC/HappyParser_760.hs
+++ b/ghc-parser/src/Language/Haskell/GHC/HappyParser_760.hs
@@ -15,7 +15,7 @@ to inline certain key external functions, so we instruct GHC not to
 throw away inlinings as it would normally do in -O0 mode.
 -}
 
-module Language.Haskell.GHC.HappyParser (
+module Language.Haskell.GHC.HappyParser_760 (
   fullModule,
   fullTypeSignature,
   fullStatement,

--- a/ghc-parser/src/Language/Haskell/GHC/HappyParser_782.hs
+++ b/ghc-parser/src/Language/Haskell/GHC/HappyParser_782.hs
@@ -7,7 +7,7 @@
 --     http://ghc.haskell.org/trac/ghc/wiki/Commentary/CodingStyle#Warnings
 -- for details
 
-module Language.Haskell.GHC.HappyParser (
+module Language.Haskell.GHC.HappyParser_782 (
   fullModule,
   fullTypeSignature,
   fullStatement,
@@ -26762,9 +26762,9 @@ happyReduction_410 ((HappyAbsSyn157  happy_var_6) `HappyStk`
 	(HappyTerminal happy_var_1) `HappyStk`
 	happyRest)
 	 = HappyAbsSyn157
-		 (sL (comb2 happy_var_1 happy_var_6) $ HsLam (mkMatchGroup FromSource [sL (comb2 happy_var_1 happy_var_6) $ Match (happy_var_2:happy_var_3) happy_var_4
+		 (sL (comb2 happy_var_1 happy_var_6) $ HsLam (mkMatchGroup [sL (comb2 happy_var_1 happy_var_6) $ Match (happy_var_2:happy_var_3) happy_var_4
                                                                 (unguardedGRHSs happy_var_6)
-                                                              ])
+                                                            ])
 	) `HappyStk` happyRest
 
 happyReduce_411 = happyReduce 4 159 happyReduction_411
@@ -26782,7 +26782,7 @@ happyReduction_412 (HappyAbsSyn185  happy_var_3)
 	_
 	(HappyTerminal happy_var_1)
 	 =  HappyAbsSyn157
-		 (sL (comb2 happy_var_1 happy_var_3) $ HsLamCase placeHolderType (mkMatchGroup FromSource (unLoc happy_var_3))
+		 (sL (comb2 happy_var_1 happy_var_3) $ HsLamCase placeHolderType (mkMatchGroup (unLoc happy_var_3))
 	)
 happyReduction_412 _ _ _  = notHappyAtAll 
 
@@ -26815,7 +26815,7 @@ happyReduction_415 ((HappyAbsSyn185  happy_var_4) `HappyStk`
 	(HappyTerminal happy_var_1) `HappyStk`
 	happyRest)
 	 = HappyAbsSyn157
-		 (sL (comb2 happy_var_1 happy_var_4) $ HsCase happy_var_2 (mkMatchGroup FromSource (unLoc happy_var_4))
+		 (sL (comb2 happy_var_1 happy_var_4) $ HsCase happy_var_2 (mkMatchGroup (unLoc happy_var_4))
 	) `HappyStk` happyRest
 
 happyReduce_416 = happySpecReduce_2  159 happyReduction_416

--- a/ghc-parser/src/Language/Haskell/GHC/HappyParser_783.hs
+++ b/ghc-parser/src/Language/Haskell/GHC/HappyParser_783.hs
@@ -7,7 +7,7 @@
 --     http://ghc.haskell.org/trac/ghc/wiki/Commentary/CodingStyle#Warnings
 -- for details
 
-module Language.Haskell.GHC.HappyParser (
+module Language.Haskell.GHC.HappyParser_783 (
   fullModule,
   fullTypeSignature,
   fullStatement,
@@ -26762,9 +26762,9 @@ happyReduction_410 ((HappyAbsSyn157  happy_var_6) `HappyStk`
 	(HappyTerminal happy_var_1) `HappyStk`
 	happyRest)
 	 = HappyAbsSyn157
-		 (sL (comb2 happy_var_1 happy_var_6) $ HsLam (mkMatchGroup [sL (comb2 happy_var_1 happy_var_6) $ Match (happy_var_2:happy_var_3) happy_var_4
+		 (sL (comb2 happy_var_1 happy_var_6) $ HsLam (mkMatchGroup FromSource [sL (comb2 happy_var_1 happy_var_6) $ Match (happy_var_2:happy_var_3) happy_var_4
                                                                 (unguardedGRHSs happy_var_6)
-                                                            ])
+                                                              ])
 	) `HappyStk` happyRest
 
 happyReduce_411 = happyReduce 4 159 happyReduction_411
@@ -26782,7 +26782,7 @@ happyReduction_412 (HappyAbsSyn185  happy_var_3)
 	_
 	(HappyTerminal happy_var_1)
 	 =  HappyAbsSyn157
-		 (sL (comb2 happy_var_1 happy_var_3) $ HsLamCase placeHolderType (mkMatchGroup (unLoc happy_var_3))
+		 (sL (comb2 happy_var_1 happy_var_3) $ HsLamCase placeHolderType (mkMatchGroup FromSource (unLoc happy_var_3))
 	)
 happyReduction_412 _ _ _  = notHappyAtAll 
 
@@ -26815,7 +26815,7 @@ happyReduction_415 ((HappyAbsSyn185  happy_var_4) `HappyStk`
 	(HappyTerminal happy_var_1) `HappyStk`
 	happyRest)
 	 = HappyAbsSyn157
-		 (sL (comb2 happy_var_1 happy_var_4) $ HsCase happy_var_2 (mkMatchGroup (unLoc happy_var_4))
+		 (sL (comb2 happy_var_1 happy_var_4) $ HsCase happy_var_2 (mkMatchGroup FromSource (unLoc happy_var_4))
 	) `HappyStk` happyRest
 
 happyReduce_416 = happySpecReduce_2  159 happyReduction_416


### PR DESCRIPTION
There might be better approaches. Fiddling around with `ghc-parser.cabal` didn't help, so I chose this.