### PR TITLE
Adding src-710 to extra source files for ghc-parser

### DIFF
--- a/ghc-parser/ghc-parser.cabal
+++ b/ghc-parser/ghc-parser.cabal
@@ -22,6 +22,7 @@ extra-source-files:
   HaskellParser76.y.pp
   HaskellParser782.y.pp
   HaskellParser783.y.pp
+  src-7.10/Language/Haskell/GHC/HappyParser.hs
 
 library
   build-tools:         happy, cpphs


### PR DESCRIPTION
Implements the change mentioned as an alternative to #478