### PR TITLE
Fix #482, bump lower bounds on aeson

### DIFF
--- a/ihaskell.cabal
+++ b/ihaskell.cabal
@@ -55,7 +55,7 @@ library
   hs-source-dirs:      src
   default-language:    Haskell2010
   build-depends:       
-                       aeson                >=0.6 && < 0.9,
+                       aeson                >=0.7 && < 0.9,
                        base                 >=4.6 && < 4.9,
                        base64-bytestring    >=1.0,
                        bytestring           >=0.10,


### PR DESCRIPTION
Bump lower bounds for `aeson` to `>=7.0`.
According to hackage, `encodeToTextBuilder` was added in `aeson-0.7.0.0`.