### PR TITLE
Temporary fix for classy-prelude

### DIFF
--- a/ihaskell-display/ihaskell-aeson/ihaskell-aeson.cabal
+++ b/ihaskell-display/ihaskell-aeson/ihaskell-aeson.cabal
@@ -59,7 +59,7 @@ library
   -- Other library packages from which modules are imported.
   build-depends:       base >=4.6 && <4.9,
                        here,
-                       classy-prelude >=0.7,
+                       classy-prelude >=0.10.5 && <0.11,
                        aeson >= 0.7,
                        aeson-pretty >= 0.7,
                        chunked-data >=0.1,

--- a/ihaskell-display/ihaskell-basic/ihaskell-basic.cabal
+++ b/ihaskell-display/ihaskell-basic/ihaskell-basic.cabal
@@ -62,7 +62,7 @@ library
              
   -- Other library packages from which modules are imported.
   build-depends:       base >=4.6 && <4.9,
-                       classy-prelude >=0.6,
+                       classy-prelude >=0.10.5 && <0.11,
                        ihaskell >= 0.5
   
   -- Directories containing source files.

--- a/ihaskell-display/ihaskell-blaze/ihaskell-blaze.cabal
+++ b/ihaskell-display/ihaskell-blaze/ihaskell-blaze.cabal
@@ -62,7 +62,7 @@ library
              
   -- Other library packages from which modules are imported.
   build-depends:       base >=4.6 && <4.9,
-                       classy-prelude >=0.6,
+                       classy-prelude >=0.10.5 && <0.11,
                        blaze-html >= 0.6,
                        blaze-markup >= 0.5,
                        ihaskell >= 0.5

--- a/ihaskell-display/ihaskell-charts/IHaskell/Display/Charts.hs
+++ b/ihaskell-display/ihaskell-charts/IHaskell/Display/Charts.hs
@@ -39,7 +39,7 @@ chartData renderable format = do
   mkFile opts filename renderable
 
   -- Convert to base64.
-  imgData <- readFile filename
+  imgData <- readFile $ fpFromString filename
   return $
     case format of
       PNG -> png width height $ base64 imgData

--- a/ihaskell-display/ihaskell-charts/ihaskell-charts.cabal
+++ b/ihaskell-display/ihaskell-charts/ihaskell-charts.cabal
@@ -59,7 +59,7 @@ library
              
   -- Other library packages from which modules are imported.
   build-depends:       base >=4.6 && <4.9,
-                       classy-prelude >=0.10.5,
+                       classy-prelude >=0.10.5 && <0.11,
                        bytestring,
                        data-default-class,
                        directory,

--- a/ihaskell-display/ihaskell-diagrams/IHaskell/Display/Diagrams.hs
+++ b/ihaskell-display/ihaskell-diagrams/IHaskell/Display/Diagrams.hs
@@ -36,7 +36,7 @@ diagramData renderable format = do
   renderCairo filename (mkSizeSpec2D (Just imgWidth) (Just imgHeight)) renderable
 
   -- Convert to base64.
-  imgData <- readFile filename
+  imgData <- readFile $ fpFromString filename
   let value =
         case format of
           PNG -> png (floor imgWidth) (floor imgHeight) $ base64 imgData

--- a/ihaskell-display/ihaskell-diagrams/IHaskell/Display/Diagrams/Animation.hs
+++ b/ihaskell-display/ihaskell-diagrams/IHaskell/Display/Diagrams/Animation.hs
@@ -47,7 +47,7 @@ animationData renderable = do
   mainRender (diagOpts, gifOpts) frameSet
 
   -- Convert to ascii represented base64 encoding
-  imgData <- readFile filename
+  imgData <- readFile $ fpFromString filename
   return . unpack . base64 $ imgData
 
 -- Rendering hint.

--- a/ihaskell-display/ihaskell-diagrams/ihaskell-diagrams.cabal
+++ b/ihaskell-display/ihaskell-diagrams/ihaskell-diagrams.cabal
@@ -59,7 +59,7 @@ library
              
   -- Other library packages from which modules are imported.
   build-depends:       base >=4.6 && <4.9,
-                       classy-prelude >=0.10.5,
+                       classy-prelude >=0.10.5 && <0.11,
                        bytestring,
                        directory,
                        -- Use diagrams wrapper package to ensure all same versions of subpackages

--- a/ihaskell-display/ihaskell-juicypixels/IHaskell/Display/Juicypixels.hs
+++ b/ihaskell-display/ihaskell-juicypixels/IHaskell/Display/Juicypixels.hs
@@ -60,7 +60,7 @@ displayImageAsJpg renderable = do
   -- Write the image
   saveJpgImage 95 filename renderable
   -- Convert to base64.
-  imgData <- readFile filename
+  imgData <- readFile $ fpFromString filename
   return $ Display [jpg (imWidth renderable) (imHeight renderable) $ base64 imgData]
 
 -- The type DynamicImage does not have a function to extract width and height

--- a/ihaskell-display/ihaskell-juicypixels/ihaskell-juicypixels.cabal
+++ b/ihaskell-display/ihaskell-juicypixels/ihaskell-juicypixels.cabal
@@ -63,7 +63,7 @@ library
              
   -- Other library packages from which modules are imported.
   build-depends:       base >=4.6 && <4.9,
-                       classy-prelude >=0.10.5,
+                       classy-prelude >=0.10.5 && <0.11,
                        bytestring,
                        directory,
                        JuicyPixels >= 3.1.3,

--- a/ihaskell-display/ihaskell-magic/ihaskell-magic.cabal
+++ b/ihaskell-display/ihaskell-magic/ihaskell-magic.cabal
@@ -62,7 +62,7 @@ library
              
   -- Other library packages from which modules are imported.
   build-depends:       base >=4.6 && <4.9,
-                       classy-prelude >=0.6,
+                       classy-prelude >=0.10.5 && <0.11,
                        magic >= 1.0.8,
                        text,
                        bytestring,

--- a/ihaskell-display/ihaskell-parsec/ihaskell-parsec.cabal
+++ b/ihaskell-display/ihaskell-parsec/ihaskell-parsec.cabal
@@ -61,7 +61,7 @@ library
   build-depends:       base >=4.6 && <4.9,
                        aeson >=0.7 && <0.9,
                        unordered-containers,
-                       classy-prelude,
+                       classy-prelude >=0.10.5 && <0.11,
                        random >= 1,
                        parsec,
                        here,

--- a/ihaskell-display/ihaskell-plot/IHaskell/Display/Plot.hs
+++ b/ihaskell-display/ihaskell-plot/IHaskell/Display/Plot.hs
@@ -31,7 +31,7 @@ figureData figure format = do
   writeFigure format fname (w, h) figure
 
   -- Read back, and convert to base64.
-  imgData <- readFile fname
+  imgData <- readFile $ fpFromString fname
   let value =
         case format of
           PNG -> png w h $ base64 imgData

--- a/ihaskell-display/ihaskell-plot/ihaskell-plot.cabal
+++ b/ihaskell-display/ihaskell-plot/ihaskell-plot.cabal
@@ -59,7 +59,7 @@ library
              
   -- Other library packages from which modules are imported.
   build-depends:       base >=4.6 && <4.9,
-                       classy-prelude >= 0.10.5,
+                       classy-prelude >= 0.10.5 && <0.11,
                        plot,
                        bytestring,
                        ihaskell >= 0.6.2

--- a/ihaskell-display/ihaskell-widgets/ihaskell-widgets.cabal
+++ b/ihaskell-display/ihaskell-widgets/ihaskell-widgets.cabal
@@ -60,7 +60,7 @@ library
   -- Other library packages from which modules are imported.
   build-depends:       base >=4.6 && <4.9,
                        aeson >=0.7 && <0.9,
-                       classy-prelude,
+                       classy-prelude >=0.10.5 && <0.11,
                        here,
                        ihaskell >= 0.4
   

--- a/src/IHaskell/Eval/Evaluate.hs
+++ b/src/IHaskell/Eval/Evaluate.hs
@@ -403,7 +403,7 @@ evalCommand _ (Module contents) state = wrapExecution state $ do
       filename = last namePieces ++ ".hs"
   liftIO $ do
     createDirectoryIfMissing True directory
-    writeFile (directory ++ filename) contents
+    writeFile (fpFromString $ directory ++ filename) contents
 
   -- Clear old modules of this name
   let modName = intercalate "." namePieces
@@ -565,7 +565,7 @@ evalCommand _ (Directive LoadFile names) state = wrapExecution state $ do
                 let filename = if endswith ".hs" name
                                  then name
                                  else name ++ ".hs"
-                contents <- readFile filename
+                contents <- readFile $ fpFromString filename
                 modName <- intercalate "." <$> getModuleName contents
                 doLoadModule filename modName
   return (ManyDisplay displays)

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -101,7 +101,7 @@ runKernel kernelOpts profileSrc = do
       libdir = kernelSpecGhcLibdir kernelOpts
 
   -- Parse the profile file.
-  Just profile <- liftM decode . readFile $ profileSrc
+  Just profile <- liftM decode . readFile . fpFromText $ profileSrc
 
   -- Necessary for `getLine` and their ilk to work.
   dir <- getIHaskellDir
@@ -131,7 +131,7 @@ runKernel kernelOpts profileSrc = do
 
     confFile <- liftIO $ kernelSpecConfFile kernelOpts
     case confFile of
-      Just filename -> liftIO (readFile filename) >>= evaluator
+      Just filename -> liftIO (readFile $ fpFromString filename) >>= evaluator
       Nothing       -> return ()
 
     forever $ do


### PR DESCRIPTION
Add the conversions betwen (String/Text) and FilePath once again.
Will have to be removed again if classy-prelude is removed.

Temporary fix for #491.