### PR TITLE
Use readFile from ByteString to read binary files

### DIFF
--- a/ihaskell-display/ihaskell-diagrams/IHaskell/Display/Diagrams.hs
+++ b/ihaskell-display/ihaskell-diagrams/IHaskell/Display/Diagrams.hs
@@ -34,11 +34,11 @@ diagramData renderable format = do
   renderCairo filename (mkSizeSpec2D (Just imgWidth) (Just imgHeight)) renderable
 
   -- Convert to base64.
-  imgData <- readFile filename
+  imgData <- Char.readFile filename
   let value =
         case format of
-          PNG -> png (floor imgWidth) (floor imgHeight) $ base64 (Char.pack imgData)
-          SVG -> svg imgData
+          PNG -> png (floor imgWidth) (floor imgHeight) $ base64 imgData
+          SVG -> svg (Char.unpack imgData)
 
   return value
 

--- a/ihaskell-display/ihaskell-diagrams/IHaskell/Display/Diagrams/Animation.hs
+++ b/ihaskell-display/ihaskell-diagrams/IHaskell/Display/Diagrams/Animation.hs
@@ -48,8 +48,8 @@ animationData renderable = do
   mainRender (diagOpts, gifOpts) frameSet
 
   -- Convert to ascii represented base64 encoding
-  imgData <- readFile filename
-  return . T.unpack . base64 . CBS.pack $ imgData
+  imgData <- CBS.readFile filename
+  return . T.unpack . base64 $ imgData
 
 -- Rendering hint.
 animation :: Animation Cairo V2 Double -> Animation Cairo V2 Double


### PR DESCRIPTION
Reading a file that might contain PNG data using `System.IO.readFile`
causes `hGetContents: invalid argument (invalid byte sequence)` due to
file contents not being valid text under the current system locale.
This fixes loading diagrams into Jupyter notebooks.