### PR TITLE
Make the example in ipython-kernel compile again

### DIFF
--- a/ipython-kernel/examples/Calc.hs
+++ b/ipython-kernel/examples/Calc.hs
@@ -213,7 +213,7 @@ mkConfig var = KernelConfig
   , displayResult = displayRes
   , displayOutput = displayOut
   , completion = langCompletion
-  , objectInfo = langInfo
+  , inspectInfo = langInfo
   , run = parseAndRun
   , debug = False
   }


### PR DESCRIPTION
Function `objectInfo` was renamed to `inpectInfo`