### PR TITLE
Allow aeson 0.9

### DIFF
--- a/ihaskell-display/ihaskell-parsec/ihaskell-parsec.cabal
+++ b/ihaskell-display/ihaskell-parsec/ihaskell-parsec.cabal
@@ -59,7 +59,7 @@ library
              
   -- Other library packages from which modules are imported.
   build-depends:       base >=4.6 && <4.9,
-                       aeson >=0.7 && <0.9,
+                       aeson >=0.7 && <0.10,
                        text,
                        unordered-containers,
                        random >= 1,

--- a/ihaskell-display/ihaskell-widgets/ihaskell-widgets.cabal
+++ b/ihaskell-display/ihaskell-widgets/ihaskell-widgets.cabal
@@ -91,7 +91,7 @@ library
   -- other-extensions:    
   
   -- Other library packages from which modules are imported.
-  build-depends:       aeson >=0.7 && < 0.9
+  build-depends:       aeson >=0.7 && < 0.10
                      , base >=4.7 && <4.9
                      , containers >= 0.5
                      , ipython-kernel >= 0.6.1.1

--- a/ihaskell.cabal
+++ b/ihaskell.cabal
@@ -54,8 +54,8 @@ flag binPkgDb
 library
   hs-source-dirs:      src
   default-language:    Haskell2010
-  build-depends:       
-                       aeson                >=0.7 && < 0.9,
+  build-depends:
+                       aeson                >=0.7 && < 0.10,
                        base                 >=4.6 && < 4.9,
                        base64-bytestring    >=1.0,
                        bytestring           >=0.10,
@@ -142,7 +142,7 @@ executable ihaskell
                        transformers         -any,
                        ghc                  >=7.6 || < 7.11,
                        here                 ==1.2.*,
-                       aeson                >=0.7 && < 0.9,
+                       aeson                >=0.7 && < 0.10,
                        bytestring           >=0.10,
                        containers           >=0.5,
                        strict               >=0.3,
@@ -166,7 +166,7 @@ Test-Suite hspec
     default-language: Haskell2010
     build-depends:
         ihaskell,
-        aeson >=0.6 && < 0.9,
+        aeson >=0.6 && < 0.10,
         base >=4.6 && < 4.9,
         base64-bytestring >=1.0,
         bytestring >=0.10,

--- a/ipython-kernel/ipython-kernel.cabal
+++ b/ipython-kernel/ipython-kernel.cabal
@@ -35,7 +35,7 @@ library
   hs-source-dirs:      src
   default-language:    Haskell2010
   build-depends:       base            >=4.6 && < 4.9,
-                       aeson           >=0.6 && < 0.9,
+                       aeson           >=0.6 && < 0.10,
                        bytestring      >=0.10,
                        cereal          >=0.3,
                        containers      >=0.5,


### PR DESCRIPTION
This will allow stackage to update to aeson 0.9 (see https://github.com/fpco/stackage/issues/572)