### PR TITLE
Removed IO, fixed JuicyPixels display

### DIFF
--- a/ihaskell-display/ihaskell-juicypixels/IHaskell/Display/Juicypixels.hs
+++ b/ihaskell-display/ihaskell-juicypixels/IHaskell/Display/Juicypixels.hs
@@ -1,94 +1,39 @@
 {-# LANGUAGE TypeSynonymInstances, FlexibleInstances #-}
 
-module IHaskell.Display.Juicypixels (module IHaskell.Display, module Codec.Picture) where
+module IHaskell.Display.Juicypixels (
+  module IHaskell.Display,
+  module Codec.Picture
+) where
 
-import           Codec.Picture
-import           IHaskell.Display
-import           System.Directory
-import           System.IO.Unsafe
-import qualified Data.ByteString.Char8 as CBS
+import qualified Codec.Picture as P
+import Codec.Picture (Image(..))
+import Codec.Picture.Png (PngSavable, encodePng)
+import IHaskell.Display (IHaskellDisplay, Display(..), display, png, base64)
+import Data.ByteString.Lazy (ByteString, toStrict)
 
--- instances
-instance IHaskellDisplay DynamicImage where
-  display = displayImageAsJpg
+instance IHaskellDisplay (Image P.Pixel8) where
+  display = return . format
 
-instance IHaskellDisplay (Image Pixel8) where
-  display = displayImageAsJpg . ImageY8
+instance IHaskellDisplay (Image P.Pixel16) where
+  display = return . format
 
-instance IHaskellDisplay (Image Pixel16) where
-  display = displayImageAsJpg . ImageY16
+instance IHaskellDisplay (Image P.PixelYA8) where
+  display = return . format
 
-instance IHaskellDisplay (Image PixelF) where
-  display = displayImageAsJpg . ImageYF
+instance IHaskellDisplay (Image P.PixelYA16) where
+  display = return . format
 
-instance IHaskellDisplay (Image PixelYA8) where
-  display = displayImageAsJpg . ImageYA8
+instance IHaskellDisplay (Image P.PixelRGB8) where
+  display = return . format
 
-instance IHaskellDisplay (Image PixelYA16) where
-  display = displayImageAsJpg . ImageYA16
+instance IHaskellDisplay (Image P.PixelRGB16) where
+  display = return . format
 
-instance IHaskellDisplay (Image PixelRGB8) where
-  display = displayImageAsJpg . ImageRGB8
+instance IHaskellDisplay (Image P.PixelRGBA8) where
+  display = return . format
 
-instance IHaskellDisplay (Image PixelRGB16) where
-  display = displayImageAsJpg . ImageRGB16
+instance IHaskellDisplay (Image P.PixelRGBA16) where
+  display = return . format
 
-instance IHaskellDisplay (Image PixelRGBF) where
-  display = displayImageAsJpg . ImageRGBF
-
-instance IHaskellDisplay (Image PixelRGBA8) where
-  display = displayImageAsJpg . ImageRGBA8
-
-instance IHaskellDisplay (Image PixelRGBA16) where
-  display = displayImageAsJpg . ImageRGBA16
-
-instance IHaskellDisplay (Image PixelYCbCr8) where
-  display = displayImageAsJpg . ImageYCbCr8
-
-instance IHaskellDisplay (Image PixelCMYK8) where
-  display = displayImageAsJpg . ImageCMYK8
-
-instance IHaskellDisplay (Image PixelCMYK16) where
-  display = displayImageAsJpg . ImageCMYK16
-
--- main rendering function
-displayImageAsJpg :: DynamicImage -> IO Display
-displayImageAsJpg renderable = do
-  switchToTmpDir
-
-  let filename = ".ihaskell.juicypixels.jpg"
-  -- Write the image
-  saveJpgImage 95 filename renderable
-  -- Convert to base64.
-  imgData <- CBS.readFile filename
-  return $ Display [jpg (imWidth renderable) (imHeight renderable) $ base64 imgData]
-
--- The type DynamicImage does not have a function to extract width and height
-imWidth :: DynamicImage -> Int
-imWidth img = w
-  where
-    (w, h) = imWidthHeight img
-
-imHeight :: DynamicImage -> Int
-imHeight img = h
-  where
-    (w, h) = imWidthHeight img
-
--- Helper functions to pattern match on the DynamicImage Constructors
-imWidthHeight :: DynamicImage -> (Int, Int)
-imWidthHeight (ImageY8 im) = imWH im
-imWidthHeight (ImageY16 im) = imWH im
-imWidthHeight (ImageYF im) = imWH im
-imWidthHeight (ImageYA8 im) = imWH im
-imWidthHeight (ImageYA16 im) = imWH im
-imWidthHeight (ImageRGB8 im) = imWH im
-imWidthHeight (ImageRGB16 im) = imWH im
-imWidthHeight (ImageRGBF im) = imWH im
-imWidthHeight (ImageRGBA8 im) = imWH im
-imWidthHeight (ImageRGBA16 im) = imWH im
-imWidthHeight (ImageYCbCr8 im) = imWH im
-imWidthHeight (ImageCMYK8 im) = imWH im
-imWidthHeight (ImageCMYK16 im) = imWH im
-
-imWH :: Image a -> (Int, Int)
-imWH im = (imageWidth im, imageHeight im)
+format :: PngSavable a => Image a -> Display
+format im@(Image w h _) = Display [png w h . base64 . toStrict . encodePng $ im]

--- a/ihaskell-display/ihaskell-juicypixels/ihaskell-juicypixels.cabal
+++ b/ihaskell-display/ihaskell-juicypixels/ihaskell-juicypixels.cabal
@@ -7,7 +7,7 @@ name:                ihaskell-juicypixels
 -- PVP summary:      +-+------- breaking API changes
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
-version:             0.3.0.0
+version:             1.1.0.0
 
 -- A short (one-line) description of the package.
 synopsis:            IHaskell - IHaskellDisplay instances of the image types of the JuicyPixels package.
@@ -29,11 +29,13 @@ license:             MIT
 license-file:        LICENSE
 
 -- The package author(s).
-author:              Roland Senn
+author:              Roland Senn,
+                     Will Yager
 
 -- An email address to which users can send suggestions, bug reports, and 
 -- patches.
-maintainer:          rsx@bluewin.ch
+maintainer:          rsx@bluewin.ch,
+                     will.yager@gmail.com
 
 -- A copyright notice.
 -- copyright:           


### PR DESCRIPTION
JuicyPixels display wasn't working. I fixed it, removed any I/O, and changed it to render PNGs.

I had to remove a few image formats to get PNG support, but if anyone complains I can add conversion code.