### PR TITLE
ihaskell-widgets and singletons >= 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ script:
    if [ ${GHCVER%.*} = "7.8" ]; then
      travis_retry ./build.sh all
    elif [ ${GHCVER%.*} = "7.10" ]; then
-     travis_retry ./build.sh all no-widgets
+     travis_retry ./build.sh all
    else
      travis_retry ./build.sh ihaskell
    fi

--- a/ghc-parser/Setup.hs
+++ b/ghc-parser/Setup.hs
@@ -1,5 +1,5 @@
 import           Distribution.Simple
-import           System.Cmd
+import           System.Process
 
 main = defaultMainWithHooks
          simpleUserHooks { preConf = \args confFlags -> do

--- a/ihaskell-display/ihaskell-widgets/Examples/Image Widget.ipynb
+++ b/ihaskell-display/ihaskell-widgets/Examples/Image Widget.ipynb
@@ -68,7 +68,7 @@
     "jpg <- get \"http://imgs.xkcd.com/comics/functional.png\"\n",
     "\n",
     "img <- mkImageWidget\n",
-    "setField img SB64Value (encode64 jpg)\n",
+    "setField img B64Value (encode64 jpg)\n",
     "img"
    ]
   },

--- a/ihaskell-display/ihaskell-widgets/Examples/String Widgets.ipynb
+++ b/ihaskell-display/ihaskell-widgets/Examples/String Widgets.ipynb
@@ -28,6 +28,7 @@
    "outputs": [],
    "source": [
     "{-# LANGUAGE OverloadedStrings #-}\n",
+    "{-# LANGUAGE FlexibleContexts #-}\n",    
     "import IHaskell.Display.Widgets"
    ]
   },

--- a/ihaskell-display/ihaskell-widgets/ihaskell-widgets.cabal
+++ b/ihaskell-display/ihaskell-widgets/ihaskell-widgets.cabal
@@ -138,3 +138,8 @@ library
   --   ghc-7.10.* = 100
   if impl(ghc == 7.8.*)
     ghc-options:       -fcontext-stack=100
+
+  -- compile without optimizations not to run out of memory on travis
+  if impl(ghc == 7.10.*)
+    ghc-options:       -O0
+

--- a/ihaskell-display/ihaskell-widgets/ihaskell-widgets.cabal
+++ b/ihaskell-display/ihaskell-widgets/ihaskell-widgets.cabal
@@ -95,20 +95,35 @@ library
   -- other-extensions:    
   
   -- Other library packages from which modules are imported.
-  build-depends:       aeson >=0.7 && < 0.11
-                     , base >=4.7 && <4.9
-                     , containers >= 0.5
-                     , ipython-kernel >= 0.6.1.2
-                     , text >= 0.11
-                     , unordered-containers -any
-                     , nats -any
-                     , vinyl >= 0.5
-                     , vector -any
-                     , singletons >= 0.9.0 && <2.0
-                     , scientific -any
-                     , unix -any
-
-                     , ihaskell >= 0.6.4.1
+  -- singletons 2.* require ghc 7.10.2
+  if impl(ghc >= 7.10.2)  
+    build-depends:       aeson >=0.7 && < 0.11
+                       , base >=4.7 && <4.9
+                       , containers >= 0.5
+                       , ipython-kernel >= 0.6.1.2
+                       , text >= 0.11
+                       , unordered-containers -any
+                       , nats -any
+                       , vinyl >= 0.5
+                       , vector -any
+                       , singletons >= 0.9.0 
+                       , scientific -any
+                       , unix -any
+                       , ihaskell >= 0.6.4.1
+  else
+    build-depends:       aeson >=0.7 && < 0.11
+                       , base >=4.7 && <4.9
+                       , containers >= 0.5
+                       , ipython-kernel >= 0.6.1.2
+                       , text >= 0.11
+                       , unordered-containers -any
+                       , nats -any
+                       , vinyl >= 0.5
+                       , vector -any
+                       , singletons >= 0.9.0 && <2.0
+                       , scientific -any
+                       , unix -any
+                       , ihaskell >= 0.6.4.1
   
   -- Directories containing source files.
   hs-source-dirs:      src

--- a/ihaskell-display/ihaskell-widgets/src/IHaskell/Display/Widgets/Singletons.hs
+++ b/ihaskell-display/ihaskell-widgets/src/IHaskell/Display/Widgets/Singletons.hs
@@ -5,10 +5,13 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE InstanceSigs #-}
 
 module IHaskell.Display.Widgets.Singletons where
 
 import           Data.Singletons.TH
+import           Data.Singletons.Prelude.Ord
 
 -- Widget properties
 singletons

--- a/ubuntu-install.sh
+++ b/ubuntu-install.sh
@@ -11,6 +11,7 @@ cabal update
 cabal install happy alex
 cabal install cpphs
 cabal install gtk2hs-buildtools
+cabal install HTTP
 
 # Build ihaskell, and all the display packages
 ./build.sh all


### PR DESCRIPTION
This patch removes a sequence of similar error messages which emerge while compiling ihaskell-widgets with singletons >= 2.0 [the latter option requires ghc >= 7.10.2].  

There is an additional minor change to ghc-parser/Setup.hs to get rid of a warning about System.Cmd, and a couple of small fixes related to the .ipynb examples for the widgets. 