### PR TITLE
Implement is_complete_{request,reply} messages

### DIFF
--- a/ipython-kernel/src/IHaskell/IPython/Message/Parser.hs
+++ b/ipython-kernel/src/IHaskell/IPython/Message/Parser.hs
@@ -83,6 +83,7 @@ parser ExecuteReplyMessage = executeReplyParser
 parser ExecuteErrorMessage = executeErrorParser
 parser ExecuteResultMessage = executeResultParser
 parser DisplayDataMessage = displayDataParser
+parser IsCompleteRequestMessage = isCompleteRequestParser
 parser CompleteRequestMessage = completeRequestParser
 parser InspectRequestMessage = inspectRequestParser
 parser ShutdownRequestMessage = shutdownRequestParser
@@ -230,6 +231,11 @@ clearOutputMessageParser :: LByteString -> Message
 clearOutputMessageParser = requestParser $ \obj -> do
   wait <- obj .: "wait"
   return $ ClearOutput noHeader wait
+
+isCompleteRequestParser :: LByteString -> Message
+isCompleteRequestParser = requestParser $ \obj -> do
+  code <- obj .: "code"
+  return $ IsCompleteRequest noHeader code
 
 completeRequestParser :: LByteString -> Message
 completeRequestParser = requestParser $ \obj -> do

--- a/ipython-kernel/src/IHaskell/IPython/Message/Parser.hs
+++ b/ipython-kernel/src/IHaskell/IPython/Message/Parser.hs
@@ -153,8 +153,8 @@ executeErrorParser = requestParser $ \obj -> do
   return $ ExecuteError noHeader [] traceback ename evalue
 
 makeDisplayDatas :: Object -> [DisplayData]
-makeDisplayDatas dataDict = [DisplayData (read $ unpack mimeType) content |
-                             (mimeType, String content) <- HM.toList dataDict]
+makeDisplayDatas dataDict = [DisplayData (read $ unpack mimeType) content | (mimeType, String content) <- HM.toList
+                                                                                                            dataDict]
 
 -- | Parse an execute result
 executeResultParser :: LByteString -> Message
@@ -173,9 +173,10 @@ displayDataParser = requestParser $ \obj -> do
   maybeSource <- obj .:? "source"
   return $ PublishDisplayData noHeader (fromMaybe "" maybeSource) displayDatas
 
-requestParser parser content = case parseEither parser decoded of
-  Right parsed -> parsed
-  Left err -> trace ("Parse error: " ++ show err) SendNothing
+requestParser parser content =
+  case parseEither parser decoded of
+    Right parsed -> parsed
+    Left err     -> trace ("Parse error: " ++ show err) SendNothing
   where
     Just decoded = decode content
 

--- a/ipython-kernel/src/IHaskell/IPython/Message/UUID.hs
+++ b/ipython-kernel/src/IHaskell/IPython/Message/UUID.hs
@@ -3,6 +3,7 @@
 -- Generate, parse, and pretty print UUIDs for use with IPython.
 module IHaskell.IPython.Message.UUID (UUID, random, randoms, uuidToString) where
 
+import           Control.Applicative ((<$>), (<*>))
 import           Control.Monad (mzero, replicateM)
 import           Data.Aeson
 import           Data.Text (pack)

--- a/ipython-kernel/src/IHaskell/IPython/Message/Writer.hs
+++ b/ipython-kernel/src/IHaskell/IPython/Message/Writer.hs
@@ -29,14 +29,22 @@ instance ToJSON Message where
       , "language_info" .= languageInfo rep
       ]
 
-  toJSON ExecuteRequest { getCode = code, getSilent = silent, getStoreHistory = storeHistory,
-                          getAllowStdin = allowStdin, getUserVariables = userVariables,
-                          getUserExpressions = userExpressions
-                        } =
-    object ["code" .= code, "silent" .= silent, "store_history" .= storeHistory,
-            "allow_stdin" .= allowStdin, "user_variables" .= userVariables,
-            "user_expressions" .= userExpressions
-           ]
+  toJSON ExecuteRequest
+    { getCode = code
+    , getSilent = silent
+    , getStoreHistory = storeHistory
+    , getAllowStdin = allowStdin
+    , getUserVariables = userVariables
+    , getUserExpressions = userExpressions
+    } =
+    object
+      [ "code" .= code
+      , "silent" .= silent
+      , "store_history" .= storeHistory
+      , "allow_stdin" .= allowStdin
+      , "user_variables" .= userVariables
+      , "user_expressions" .= userExpressions
+      ]
 
   toJSON ExecuteReply { status = status, executionCounter = counter, pagerOutput = pager } =
     object

--- a/ipython-kernel/src/IHaskell/IPython/Message/Writer.hs
+++ b/ipython-kernel/src/IHaskell/IPython/Message/Writer.hs
@@ -7,6 +7,7 @@
 module IHaskell.IPython.Message.Writer (ToJSON(..)) where
 
 import           Data.Aeson
+import           Data.Aeson.Types (Pair)
 import           Data.Map (Map)
 import           Data.Monoid (mempty)
 import           Data.Text (Text, pack)
@@ -129,6 +130,18 @@ instance ToJSON Message where
       tuplify (HistoryReplyElement sess linum res) = (sess, linum, case res of
                                                                      Left inp         -> toJSON inp
                                                                      Right (inp, out) -> toJSON out)
+
+  toJSON req@IsCompleteReply{} =
+    object pairs
+    where
+      pairs =
+        case reviewResult req of
+          CodeComplete       -> status "complete"
+          CodeIncomplete ind -> status "incomplete" ++ indent ind
+          CodeInvalid        -> status "invalid"
+          CodeUnknown        -> status "unknown"
+      status x = ["status" .= pack x]
+      indent x = ["indent" .= pack x]
 
   toJSON body = error $ "Do not know how to convert to JSON for message " ++ show body
 

--- a/ipython-kernel/src/IHaskell/IPython/Message/Writer.hs
+++ b/ipython-kernel/src/IHaskell/IPython/Message/Writer.hs
@@ -8,6 +8,7 @@ module IHaskell.IPython.Message.Writer (ToJSON(..)) where
 
 import           Data.Aeson
 import           Data.Map (Map)
+import           Data.Monoid (mempty)
 import           Data.Text (Text, pack)
 import           IHaskell.IPython.Types
 

--- a/ipython-kernel/src/IHaskell/IPython/Types.hs
+++ b/ipython-kernel/src/IHaskell/IPython/Types.hs
@@ -115,7 +115,7 @@ instance ToJSON Transport where
 -------------------- IPython Kernelspec Types ----------------------
 data KernelSpec =
        KernelSpec
-         {
+         { 
          -- | Name shown to users to describe this kernel (e.g. "Haskell")
          kernelDisplayName :: String
          -- | Name for the kernel; unique kernel identifier (e.g. "haskell")
@@ -278,7 +278,7 @@ data Message =
                  , languageInfo :: LanguageInfo
                  }
              |
-               -- | A request from a frontend to execute some code.
+             -- | A request from a frontend to execute some code.
                ExecuteInput
                  { header :: MessageHeader
                  , getCode :: Text         -- ^ The code string.
@@ -349,17 +349,10 @@ data Message =
                  , inCode :: String                      -- ^ Submitted input code.
                  , executionCount :: Int                 -- ^ Which input this is.
                  }
-             | Input
-                 { header :: MessageHeader
-                 , getCode :: Text
-                 , executionCount :: Int
-                 }
-             | Output
-                 { header :: MessageHeader
-                 , getText :: [DisplayData]
-                 , executionCount :: Int
-                 }
-             | CompleteRequest
+             | Input { header :: MessageHeader, getCode :: Text, executionCount :: Int }
+             | Output { header :: MessageHeader, getText :: [DisplayData], executionCount :: Int }
+             |
+               CompleteRequest
                  { header :: MessageHeader
                  , getCode :: Text  {- ^
             The entire block of text where the line is. This may be useful in the
@@ -488,7 +481,6 @@ instance FromJSON StreamType where
   parseJSON (String "stdin") = return Stdin
   parseJSON (String "stdout") = return Stdout
   parseJSON (String "stderr") = return Stderr
-
 
 -- | Get the reply message type for a request message type.
 replyType :: MessageType -> Maybe MessageType

--- a/ipython-kernel/src/IHaskell/IPython/Types.hs
+++ b/ipython-kernel/src/IHaskell/IPython/Types.hs
@@ -35,6 +35,7 @@ module IHaskell.IPython.Types (
     extractPlain,
     ) where
 
+import           Control.Applicative ((<$>), (<*>))
 import           Data.Aeson
 import           Data.ByteString (ByteString)
 import           Data.List (find)

--- a/ipython-kernel/src/IHaskell/IPython/ZeroMQ.hs
+++ b/ipython-kernel/src/IHaskell/IPython/ZeroMQ.hs
@@ -37,7 +37,7 @@ import           IHaskell.IPython.Types
 -- should functionally serve as high-level sockets which speak Messages instead of ByteStrings.
 data ZeroMQInterface =
        Channels
-         {
+         { 
          -- | A channel populated with requests from the frontend.
          shellRequestChannel :: Chan Message
          -- | Writing to this channel causes a reply to be sent to the frontend.

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -306,6 +306,11 @@ replyTo interface req@ExecuteRequest { getCode = code } replyHeader state = do
                      , status = Ok
                      })
 
+-- Always assume that the code is complete, which allows for only
+-- single line inputs for now.
+replyTo _ IsCompleteRequest{} replyHeader state = do
+  let reply = IsCompleteReply { header = replyHeader, reviewResult = CodeComplete }
+  return (state, reply)
 
 replyTo _ req@CompleteRequest{} replyHeader state = do
   let code = getCode req


### PR DESCRIPTION
These messages are used by console frontends to check whether the
current input is complete or not. If it is not complete, the next line
is treated as the continuation of the code, and a '...' prompt is used
to show that.

To provide support for qtconsole, I have made it such that IHaskell
always responds to an is_complete_request by saying that the code is
complete, which only allows for single line inputs.

Ping @kfiz.