### PR TITLE
Fix test example for juicypixels

### DIFF
--- a/ihaskell-display/ihaskell-juicypixels/test.ipynb
+++ b/ihaskell-display/ihaskell-juicypixels/test.ipynb
@@ -1,42 +1,52 @@
 {
- "metadata": {
-  "language": "haskell",
-  "name": "",
-  "signature": "sha256:b9b36c162e37a16b252cd1f06e4c2991e0a80710e7fc184be82dd6b18e6dcf01"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "{-# LANGUAGE NoImplicitPrelude, TypeSynonymInstances, FlexibleInstances  #-}\n",
-      "\n",
-      "import IHaskell.Display.Juicypixels\n",
-      "   \n",
-      "myImage = generateImage pixelRenderer 250 300\n",
-      "    where pixelRenderer x y = PixelRGB8 (fromIntegral x) (fromIntegral y) 128\n",
-      "    \n",
-      "myImage    "
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 8
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    }
-   ],
-   "metadata": {}
+   "cell_type": "markdown",
+   "metadata": {
+    "hidden": false
+   },
+   "source": [
+    "# Notebook test\n",
+    "\n",
+    "This IHaskell noteook should just test, whether IHaskell and JuicyPixels are properly installed and working.\n",
+    "\n",
+    "Just click in the box below and click on the \"Run\" command in the above menu.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "hidden": false
+   },
+   "outputs": [],
+   "source": [
+    "{-# LANGUAGE TypeSynonymInstances, FlexibleInstances  #-}\n",
+    "\n",
+    "import IHaskell.Display.Juicypixels\n",
+    "import Codec.Picture\n",
+    "   \n",
+    "myImage = generateImage pixelRenderer 250 300\n",
+    "    where pixelRenderer x y = PixelRGB8 (fromIntegral x) (fromIntegral y) 128\n",
+    "    \n",
+    "myImage    "
+   ]
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Haskell",
+   "language": "haskell",
+   "name": "haskell"
+  },
+  "language_info": {
+   "codemirror_mode": "ihaskell",
+   "file_extension": ".hs",
+   "name": "haskell",
+   "version": "7.10.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }


### PR DESCRIPTION
The example in the notebook for ihaskell-juicypixels is still on V3. It gives several compiler errors.
Here is a fix, converted to V4.
