### PR TITLE
Show "Current Kernel Information" in Jupyter Notebook About

### DIFF
--- a/ipython-kernel/src/IHaskell/IPython/Message/Writer.hs
+++ b/ipython-kernel/src/IHaskell/IPython/Message/Writer.hs
@@ -25,7 +25,7 @@ instance ToJSON LanguageInfo where
 instance ToJSON Message where
   toJSON rep@KernelInfoReply{} =
     object
-      [ "protocol_version" .= string "5.0"  -- current protocol version, major and minor
+      [ "protocol_version" .= protocolVersion rep
       , "banner" .= banner rep
       , "implementation" .= implementation rep
       , "implementation_version" .= implementationVersion rep

--- a/ipython-kernel/src/IHaskell/IPython/Message/Writer.hs
+++ b/ipython-kernel/src/IHaskell/IPython/Message/Writer.hs
@@ -26,6 +26,7 @@ instance ToJSON Message where
   toJSON rep@KernelInfoReply{} =
     object
       [ "protocol_version" .= string "5.0"  -- current protocol version, major and minor
+      , "banner" .= banner rep
       , "implementation" .= implementation rep
       , "implementation_version" .= implementationVersion rep
       , "language_info" .= languageInfo rep

--- a/ipython-kernel/src/IHaskell/IPython/Types.hs
+++ b/ipython-kernel/src/IHaskell/IPython/Types.hs
@@ -287,6 +287,7 @@ data Message =
              -- | A response to a KernelInfoRequest.
                KernelInfoReply
                  { header :: MessageHeader
+                 , protocolVersion :: String -- ^ current protocol version, major and minor
                  , banner :: String -- ^ Kernel information description e.g. (IHaskell 0.8.3.0 GHC 7.10.2)
                  , implementation :: String -- ^ e.g. IHaskell
                  , implementationVersion :: String -- ^ The version of the implementation

--- a/ipython-kernel/src/IHaskell/IPython/Types.hs
+++ b/ipython-kernel/src/IHaskell/IPython/Types.hs
@@ -287,6 +287,7 @@ data Message =
              -- | A response to a KernelInfoRequest.
                KernelInfoReply
                  { header :: MessageHeader
+                 , banner :: String -- ^ Kernel information description e.g. (IHaskell 0.8.3.0 GHC 7.10.2)
                  , implementation :: String -- ^ e.g. IHaskell
                  , implementationVersion :: String -- ^ The version of the implementation
                  , languageInfo :: LanguageInfo

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -239,6 +239,7 @@ replyTo _ KernelInfoRequest{} replyHeader state =
   return
     (state, KernelInfoReply
               { header = replyHeader
+              , protocolVersion = "5.0"
               , banner = "IHaskell " ++ VERSION_ipython_kernel ++ " GHC " ++ VERSION_ghc
               , implementation = "IHaskell"
               , implementationVersion = VERSION_ipython_kernel

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -239,6 +239,7 @@ replyTo _ KernelInfoRequest{} replyHeader state =
   return
     (state, KernelInfoReply
               { header = replyHeader
+              , banner = "IHaskell " ++ VERSION_ipython_kernel ++ " GHC " ++ VERSION_ghc
               , implementation = "IHaskell"
               , implementationVersion = VERSION_ipython_kernel
               , languageInfo = LanguageInfo


### PR DESCRIPTION
#632 

Populating the <code>banner</code> field allows the Help>About tab in notebook to show IHaskell version. It's convenient to also show the GHC version being used.

The protocol version info was only added in the toJSON method, which doesn't seem right. I've moved it to <code>Main.hs</code> where the rest of the kernel information is provided.

Screenshot of the output in the About section can be seen in the issue page.