### PR TITLE
Support --version, -V in CLI

### DIFF
--- a/main/Main.hs
+++ b/main/Main.hs
@@ -28,6 +28,7 @@ import           System.Posix.Signals
 import qualified Data.Map as Map
 import qualified Data.Text.Encoding as E
 import           Data.List (break, last)
+import           Data.Version (showVersion)
 
 -- IHaskell imports.
 import           IHaskell.Convert (convert)
@@ -45,6 +46,9 @@ import           IHaskell.IPython.ZeroMQ
 import           IHaskell.IPython.Types
 import qualified IHaskell.IPython.Message.UUID as UUID
 import qualified IHaskell.IPython.Stdin as Stdin
+
+-- Cabal imports.
+import           Paths_ihaskell(version)
 
 -- GHC API imports.
 import           GHC hiding (extensions, language)
@@ -86,7 +90,7 @@ showDefault :: String -> [Argument] -> IO ()
 showDefault helpStr flags =
   case find (== Version) flags of
   Just _ ->
-    putStrLn VERSION_ipython_kernel
+    putStrLn (showVersion version)
   Nothing ->
     putStrLn helpStr
 
@@ -248,9 +252,9 @@ replyTo _ KernelInfoRequest{} replyHeader state =
     (state, KernelInfoReply
               { header = replyHeader
               , protocolVersion = "5.0"
-              , banner = "IHaskell " ++ VERSION_ipython_kernel ++ " GHC " ++ VERSION_ghc
+              , banner = "IHaskell " ++ (showVersion version) ++ " GHC " ++ VERSION_ghc
               , implementation = "IHaskell"
-              , implementationVersion = VERSION_ipython_kernel
+              , implementationVersion = showVersion version
               , languageInfo = LanguageInfo
                 { languageName = "haskell"
                 , languageVersion = VERSION_ghc

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -69,7 +69,7 @@ main = do
     Right args        -> ihaskell args
 
 ihaskell :: Args -> IO ()
-ihaskell (Args (ShowHelp help) _) = putStrLn help
+ihaskell (Args (ShowDefault helpStr) args) = showDefault helpStr args
 ihaskell (Args ConvertLhs args) = showingHelp ConvertLhs args $ convert args
 ihaskell (Args InstallKernelSpec args) = showingHelp InstallKernelSpec args $ do
   let kernelSpecOpts = parseKernelArgs args
@@ -81,6 +81,14 @@ ihaskell a@(Args (Kernel Nothing) _) = do
   hPutStrLn stderr "No kernel profile JSON specified."
   hPutStrLn stderr "This may be a bug!"
   hPrint stderr a
+
+showDefault :: String -> [Argument] -> IO ()
+showDefault helpStr flags =
+  case find (== Version) flags of
+  Just _ ->
+    putStrLn VERSION_ipython_kernel
+  Nothing ->
+    putStrLn helpStr
 
 showingHelp :: IHaskellMode -> [Argument] -> IO () -> IO ()
 showingHelp mode flags act =

--- a/src/IHaskell/Flags.hs
+++ b/src/IHaskell/Flags.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP, NoImplicitPrelude, DeriveFunctor #-}
+{-# LANGUAGE NoImplicitPrelude, DeriveFunctor #-}
 
 module IHaskell.Flags (
     IHaskellMode(..),
@@ -58,7 +58,7 @@ data NotebookFormat = LhsMarkdown
   deriving (Eq, Show)
 
 -- Which mode IHaskell is being invoked in.
-data IHaskellMode = ShowHelp String
+data IHaskellMode = ShowDefault String
                   | InstallKernelSpec
                   | ConvertLhs
                   | Kernel (Maybe String)
@@ -71,9 +71,7 @@ parseFlags flags =
   in case modeIndex of
     Nothing ->
       -- Treat no mode as 'console'.
-      if "--version" `elem` flags || "-V" `elem` flags
-        then Left VERSION_ipython_kernel
-        else process ihaskellArgs flags
+      process ihaskellArgs flags
     Just 0 -> process ihaskellArgs flags
 
     Just idx ->
@@ -179,7 +177,7 @@ lhsStyleTex = LhsStyle "" "" "\\begin{code}" "\\end{code}" "\\begin{verbatim}" "
 ihaskellArgs :: Mode Args
 ihaskellArgs =
   let noMode = mode "IHaskell" defaultReport descr noArgs [helpFlag, versionFlag]
-      defaultReport = Args (ShowHelp helpStr) []
+      defaultReport = Args (ShowDefault helpStr) []
       descr = "Haskell for Interactive Computing."
       helpFlag = flagHelpSimple (add Help)
       versionFlag = flagVersion (add Version)

--- a/src/IHaskell/Flags.hs
+++ b/src/IHaskell/Flags.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE NoImplicitPrelude, DeriveFunctor #-}
+{-# LANGUAGE CPP, NoImplicitPrelude, DeriveFunctor #-}
 
 module IHaskell.Flags (
     IHaskellMode(..),
@@ -32,6 +32,7 @@ data Argument = ConfFile String     -- ^ A file with commands to load at startup
               | GhcLibDir String    -- ^ Where to find the GHC libraries.
               | KernelDebug         -- ^ Spew debugging output from the kernel.
               | Help                -- ^ Display help text.
+              | Version             -- ^ Display version text.
               | ConvertFrom String
               | ConvertTo String
               | ConvertFromFormat NotebookFormat
@@ -70,8 +71,8 @@ parseFlags flags =
   in case modeIndex of
     Nothing ->
       -- Treat no mode as 'console'.
-      if "--help" `elem` flags
-        then Left $ showText (Wrap 100) $ helpText [] HelpFormatAll ihaskellArgs
+      if "--version" `elem` flags || "-V" `elem` flags
+        then Left VERSION_ipython_kernel
         else process ihaskellArgs flags
     Just 0 -> process ihaskellArgs flags
 
@@ -177,10 +178,12 @@ lhsStyleTex = LhsStyle "" "" "\\begin{code}" "\\end{code}" "\\begin{verbatim}" "
 
 ihaskellArgs :: Mode Args
 ihaskellArgs =
-  let descr = "Haskell for Interactive Computing."
+  let noMode = mode "IHaskell" defaultReport descr noArgs [helpFlag, versionFlag]
+      defaultReport = Args (ShowHelp helpStr) []
+      descr = "Haskell for Interactive Computing."
+      helpFlag = flagHelpSimple (add Help)
+      versionFlag = flagVersion (add Version)
       helpStr = showText (Wrap 100) $ helpText [] HelpFormatAll ihaskellArgs
-      onlyHelp = [flagHelpSimple (add Help)]
-      noMode = mode "IHaskell" (Args (ShowHelp helpStr) []) descr noArgs onlyHelp
   in noMode { modeGroupModes = toGroup allModes }
   where
     add flag (Args mode flags) = Args mode $ flag : flags


### PR DESCRIPTION
Sample Output:

    $ ihaskell --version
    0.8.3.0

    $ ihaskell -V
    0.8.3.0

Two points:

**First**: Adding <code>versionFlag</code> to <code>iHaskellArgs</code> displays the <code>-V --version</code> in the help command.
    
    IHaskell [COMMAND] ... [OPTIONS]
      Haskell for Interactive Computing.

      -? --help                  Display help message
      -V --version               Print version information

    IHaskell install [OPTIONS]
      Install the Jupyter kernelspec.

      -l --ghclib=<path>         Library directory for GHC.
         --debug                 Print debugging output from the kernel.
      -c --conf=<rc.hs>          File with commands to execute at start; replaces ~/.ihaskell/rc.hs.
         --prefix=<install-dir>  Installation prefix for kernelspec (see Jupyter's --prefix option)
      -? --help                  Display help message
         --stack                 Inherit environment from `stack` when it is installed

    IHaskell kernel [OPTIONS] <json-kernel-file>
      Invoke the IHaskell kernel.

      -l --ghclib=<path>         Library directory for GHC.
         --debug                 Print debugging output from the kernel.
      -c --conf=<rc.hs>          File with commands to execute at start; replaces ~/.ihaskell/rc.hs.
         --stack                 Inherit environment from `stack` when it is installed

    IHaskell convert [OPTIONS] <file>
      Convert between Literate Haskell (*.lhs) and Ipython notebooks (*.ipynb).

      -i --input=<file>          File to read.
      -o --output=<file>         File to write.
      -f --from=lhs|ipynb        Format of the file to read.
      -t --to=lhs|ipynb          Format of the file to write.
         --force                 Overwrite existing files with output.
      -s --style=bird|tex        Type of markup used for the literate haskell file
         --bird                  Literate haskell uses >
         --tex                   Literate haskell uses \begin{code}
      -? --help                  Display help message


Adding the subsequent lines to parseFlags allows the detection of <code>-V --version</code> flags so it can output the version accordingly.

    if "--version" `elem` flags || "-V" `elem` flags
      then Left VERSION_ipython_kernel

**Please help:** To me this seems like an incorrect place to put the check, but I'm not sure how to convert the version display into an <code>IHaskellMode</code>, if my intuition is correct.

**Second**: I removed the <code>if "--help" `elem` flags</code> in parseFlags because having them removed appears to not change its behavior in the command line.