### PR TITLE
Tolerate bad messages in parseHeader

### DIFF
--- a/ipython-kernel/src/IHaskell/IPython/Message/UUID.hs
+++ b/ipython-kernel/src/IHaskell/IPython/Message/UUID.hs
@@ -3,7 +3,6 @@
 -- Generate, parse, and pretty print UUIDs for use with IPython.
 module IHaskell.IPython.Message.UUID (UUID, random, randoms, uuidToString) where
 
-import           Control.Applicative ((<$>), (<*>))
 import           Control.Monad (mzero, replicateM)
 import           Data.Aeson
 import           Data.Text (pack)

--- a/ipython-kernel/src/IHaskell/IPython/Message/Writer.hs
+++ b/ipython-kernel/src/IHaskell/IPython/Message/Writer.hs
@@ -7,9 +7,7 @@
 module IHaskell.IPython.Message.Writer (ToJSON(..)) where
 
 import           Data.Aeson
-import           Data.Aeson.Types (Pair)
 import           Data.Map (Map)
-import           Data.Monoid (mempty)
 import           Data.Text (Text, pack)
 import           IHaskell.IPython.Types
 
@@ -82,6 +80,13 @@ instance ToJSON Message where
       ]
   toJSON PublishInput { executionCount = execCount, inCode = code } =
     object ["execution_count" .= execCount, "code" .= code]
+
+  toJSON (CompleteRequest _ code pos) =
+    object
+      [ "code" .= code
+      , "cursor_pos" .= pos
+      ]
+
   toJSON (CompleteReply _ matches start end metadata status) =
     object
       [ "matches" .= matches

--- a/ipython-kernel/src/IHaskell/IPython/Types.hs
+++ b/ipython-kernel/src/IHaskell/IPython/Types.hs
@@ -36,7 +36,6 @@ module IHaskell.IPython.Types (
     extractPlain,
     ) where
 
-import           Control.Applicative ((<$>), (<*>))
 import           Data.Aeson
 import           Data.ByteString (ByteString)
 import           Data.List (find)
@@ -117,7 +116,7 @@ instance ToJSON Transport where
 -------------------- IPython Kernelspec Types ----------------------
 data KernelSpec =
        KernelSpec
-         { 
+         {
          -- | Name shown to users to describe this kernel (e.g. "Haskell")
          kernelDisplayName :: String
          -- | Name for the kernel; unique kernel identifier (e.g. "haskell")

--- a/ipython-kernel/src/IHaskell/IPython/ZeroMQ.hs
+++ b/ipython-kernel/src/IHaskell/IPython/ZeroMQ.hs
@@ -37,7 +37,7 @@ import           IHaskell.IPython.Types
 -- should functionally serve as high-level sockets which speak Messages instead of ByteStrings.
 data ZeroMQInterface =
        Channels
-         { 
+         {
          -- | A channel populated with requests from the frontend.
          shellRequestChannel :: Chan Message
          -- | Writing to this channel causes a reply to be sent to the frontend.
@@ -283,8 +283,12 @@ receiveMessage debug socket = do
     putStr "Content: "
     Char.putStrLn content
 
-  let message = parseMessage idents headerData parentHeader metadata content
-  return message
+  case parseMessage idents headerData parentHeader metadata content of
+    Left s -> do
+      when debug $ do
+        putStrLn $ "Failed to parse message: " ++ s
+      receiveMessage debug socket
+    Right message -> return message
 
   where
     -- Receive the next piece of data from the socket.


### PR DESCRIPTION
This PR contains a couple tweaks from my work with IHaskell. The main one is to be a little more tolerant of ill-formed messages, since many Jupyter kernels are not perfect -- clojupyter, for example, outputs messages with the weird message type of "execute-content".

This PR also adds `CompleteReply` and `CompleteReplyParser` for autocomplete.
