### PR TITLE
ihaskell.cabal: add missing 'here' depend into testsuite

### DIFF
--- a/ihaskell.cabal
+++ b/ihaskell.cabal
@@ -180,6 +180,7 @@ Test-Suite hspec
         haskeline -any,
         hlint >=1.9 && <2.0,
         haskell-src-exts     >=1.16 && < 1.18,
+        here,
         hspec -any,
         HUnit -any,
         mtl >=2.1,


### PR DESCRIPTION
Preprocessing test suite 'hspec' for ihaskell-0.8.4.0...

Hspec.hs:20:18:
    Could not find module ‘Data.String.Here’
    It is a member of the hidden package ‘here-1.2.7@here_1j09jYtlmBB7SYT9WO9k1d’.
    Perhaps you need to add ‘here’ to the build-depends in your .cabal file.
    Use -v to see a list of the files searched for.

Signed-off-by: Sergei Trofimovich <siarheit@google.com>