### PR TITLE
Constrain dependecy of `ipython-kernel` to actually match the version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,14 +19,9 @@ before_install:
  - travis_retry git clone http://www.github.com/zeromq/zeromq4-x.git libzmq
  - export OLDPWD=$(pwd) && cd libzmq && travis_retry ./autogen.sh && travis_retry ./configure && make && travis_retry sudo make install && travis_retry sudo ldconfig && cd $OLDPWD
  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.cabal/bin:$PATH
- - |
-   if [ $GHCVER = "head" ] || [ ${GHCVER%.*} = "7.8" ] || [ ${GHCVER%.*} = "7.10" ]; then
-     travis_retry sudo apt-get install happy-1.19.4 alex-3.1.3
-     travis_retry sudo apt-get install libblas-dev liblapack-dev
-     export PATH=/opt/alex/3.1.3/bin:/opt/happy/1.19.4/bin:$PATH
-   else
-     travis_retry sudo apt-get install happy alex
-   fi
+ - travis_retry sudo apt-get install happy-1.19.4 alex-3.1.3
+ - export PATH=/opt/alex/3.1.3/bin:/opt/happy/1.19.4/bin:$PATH
+ - travis_retry sudo apt-get install libblas-dev liblapack-dev
 
 install:
  - cabal --version

--- a/ihaskell.cabal
+++ b/ihaskell.cabal
@@ -87,7 +87,7 @@ library
                        utf8-string          -any,
                        uuid                 >=1.3,
                        vector               -any,
-                       ipython-kernel       >=0.7
+                       ipython-kernel       >=0.8.4
   if flag(binPkgDb)
     build-depends:       bin-package-db
 


### PR DESCRIPTION
Previously, `cabal install ihaskell` would happily use ipython-kernel-0.8.3, resulting in error

```
[3 of 3] Compiling Main             ( main/Main.hs, dist/build/ihaskell/ihaskell-tmp/Main.o )

main/Main.hs:254:17:
    ‘protocolVersion’ is not a (visible) field of constructor ‘KernelInfoReply’

main/Main.hs:255:17:
    ‘banner’ is not a (visible) field of constructor ‘KernelInfoReply’
cabal: Error: some packages failed to install:
ihaskell-0.8.4.0 failed during the building phase. The exception was:
ExitFailure 1
```

This is not possible anymore, with the correct dependency.