### PR TITLE
Add a package flag to cryptonite

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,6 @@
 flags: {}
+ghc-options:
+  cryptonite: -opta-Wa,-mrelax-relocations=no
 packages:
 - '.'
 - ipython-kernel/


### PR DESCRIPTION
Suggestion from: https://github.com/DanielG/ghc-mod/issues/762
Addresses: #636

I do not fully understand the implications of this change, but it fixed the problem for me (once I forced stack to rebuild `cryptonite`)