### PR TITLE
Escape html control characters in error messages.

### DIFF
--- a/src/IHaskell/Eval/Evaluate.hs
+++ b/src/IHaskell/Eval/Evaluate.hs
@@ -1315,17 +1315,17 @@ formatErrorWithClass :: String -> ErrMsg -> String
 formatErrorWithClass cls =
   printf "<span class='%s'>%s</span>" cls .
   replace "\n" "<br/>" .
+  fixDollarSigns .
   replace "<" "&lt;" .
   replace ">" "&gt;" .
   replace "&" "&amp;" .
   replace useDashV "" .
   replace "Ghci" "IHaskell" .
   replace "‘interactive:" "‘" .
-  fixDollarSigns .
   rstrip .
   typeCleaner
   where
-    fixDollarSigns = replace "$" "<span>$</span>"
+    fixDollarSigns = replace "$" "<span>&dollar;</span>"
     useDashV = "\nUse -v to see a list of the files searched for."
     isShowError err =
       "No instance for (Show" `isPrefixOf` err &&

--- a/src/IHaskell/Eval/Evaluate.hs
+++ b/src/IHaskell/Eval/Evaluate.hs
@@ -1315,6 +1315,9 @@ formatErrorWithClass :: String -> ErrMsg -> String
 formatErrorWithClass cls =
   printf "<span class='%s'>%s</span>" cls .
   replace "\n" "<br/>" .
+  replace "<" "&lt;" .
+  replace ">" "&gt;" .
+  replace "&" "&amp;" .
   replace useDashV "" .
   replace "Ghci" "IHaskell" .
   replace "‘interactive:" "‘" .


### PR DESCRIPTION
Error messages are usually rendered surprisingly clean even without escaping, but in a few cases it went wrong quite badly, in particular the `<<loop>>` error would get rendered as the completely cryptic

    <>

Also, something like `"one string&quot; &quot;another string" 4` used to give the error message

```
The function ‘"one string" "another string"’ is applied to one argument,
but its type ‘String’ has none
```

This kind of behavior is prevented by escaping the characters `<`, `>` and `&` to `&lt;`, `&gt;` and `&amp;`, respectively.