### PR TITLE
Add CommInfoRequest and CommInfoReply

### DIFF
--- a/ipython-kernel/src/IHaskell/IPython/EasyKernel.hs
+++ b/ipython-kernel/src/IHaskell/IPython/EasyKernel.hs
@@ -178,7 +178,7 @@ replyTo config _ _ CommInfoRequest{} replyHeader =
   return
     CommInfoReply
       { header = replyHeader
-      , commInfo = [] }
+      , commInfo = mempty }
 
 replyTo config _ interface ShutdownRequest { restartPending = pending } replyHeader = do
   liftIO $ writeChan (shellReplyChannel interface) $ ShutdownReply replyHeader pending

--- a/ipython-kernel/src/IHaskell/IPython/EasyKernel.hs
+++ b/ipython-kernel/src/IHaskell/IPython/EasyKernel.hs
@@ -174,6 +174,12 @@ replyTo config _ _ KernelInfoRequest{} replyHeader =
       , protocolVersion = kernelProtocolVersion config
       }
 
+replyTo config _ _ CommInfoRequest{} replyHeader =
+  return
+    CommInfoReply
+      { header = replyHeader
+      , commInfo = [] }
+
 replyTo config _ interface ShutdownRequest { restartPending = pending } replyHeader = do
   liftIO $ writeChan (shellReplyChannel interface) $ ShutdownReply replyHeader pending
   liftIO exitSuccess

--- a/ipython-kernel/src/IHaskell/IPython/Message/Parser.hs
+++ b/ipython-kernel/src/IHaskell/IPython/Message/Parser.hs
@@ -90,6 +90,7 @@ parser ShutdownRequestMessage = shutdownRequestParser
 parser InputReplyMessage = inputReplyParser
 parser CommOpenMessage = commOpenParser
 parser CommDataMessage = commDataParser
+parser CommInfoRequestMessage = commInfoRequestParser
 parser CommCloseMessage = commCloseParser
 parser HistoryRequestMessage = historyRequestParser
 parser StatusMessage = statusMessageParser
@@ -103,6 +104,11 @@ parser other = error $ "Unknown message type " ++ show other
 -- body.
 kernelInfoRequestParser :: LByteString -> Message
 kernelInfoRequestParser _ = KernelInfoRequest { header = noHeader }
+
+-- | Parse a comm info request. A comm info request has no auxiliary information, so ignore the
+-- body.
+commInfoRequestParser :: LByteString -> Message
+commInfoRequestParser _ = CommInfoRequest { header = noHeader }
 
 -- | Parse an execute_input response. Fields used are:
 executeInputParser :: LByteString -> Message

--- a/ipython-kernel/src/IHaskell/IPython/Message/Writer.hs
+++ b/ipython-kernel/src/IHaskell/IPython/Message/Writer.hs
@@ -11,6 +11,7 @@ import           Data.Aeson.Types (Pair)
 import           Data.Map (Map)
 import           Data.Monoid (mempty)
 import           Data.Text (Text, pack)
+import qualified Data.Map               as Map
 import           IHaskell.IPython.Types
 
 instance ToJSON LanguageInfo where
@@ -37,7 +38,7 @@ instance ToJSON Message where
     , commInfo = commInfo
     } =
     object
-      [ "comm_info" .= commInfo ]
+      [ "comms" .= Map.map (\comm -> object ["target_name" .= comm]) commInfo ]
 
   toJSON ExecuteRequest
     { getCode = code

--- a/ipython-kernel/src/IHaskell/IPython/Message/Writer.hs
+++ b/ipython-kernel/src/IHaskell/IPython/Message/Writer.hs
@@ -32,6 +32,13 @@ instance ToJSON Message where
       , "language_info" .= languageInfo rep
       ]
 
+  toJSON CommInfoReply
+    { header = header
+    , commInfo = commInfo
+    } =
+    object
+      [ "comm_info" .= commInfo ]
+
   toJSON ExecuteRequest
     { getCode = code
     , getSilent = silent

--- a/ipython-kernel/src/IHaskell/IPython/Types.hs
+++ b/ipython-kernel/src/IHaskell/IPython/Types.hs
@@ -306,7 +306,7 @@ data Message =
              -- | A response to a CommInfoRequest.
                CommInfoReply
                  { header   :: MessageHeader
-                 , commInfo :: [(String, String)] -- ^ A dictionary of the comms, indexed by uuids.
+                 , commInfo :: Map String String -- ^ A dictionary of the comms, indexed by uuids.
                  }
              |
              -- | A request from a frontend to execute some code.

--- a/ipython-kernel/src/IHaskell/IPython/Types.hs
+++ b/ipython-kernel/src/IHaskell/IPython/Types.hs
@@ -193,6 +193,8 @@ data MessageType = KernelInfoReplyMessage
                  | InputReplyMessage
                  | CommOpenMessage
                  | CommDataMessage
+                 | CommInfoRequestMessage
+                 | CommInfoReplyMessage
                  | CommCloseMessage
                  | HistoryRequestMessage
                  | HistoryReplyMessage
@@ -224,6 +226,8 @@ showMessageType InputRequestMessage = "input_request"
 showMessageType InputReplyMessage = "input_reply"
 showMessageType CommOpenMessage = "comm_open"
 showMessageType CommDataMessage = "comm_msg"
+showMessageType CommInfoRequestMessage = "comm_info_request"
+showMessageType CommInfoReplyMessage = "comm_info_reply"
 showMessageType CommCloseMessage = "comm_close"
 showMessageType HistoryRequestMessage = "history_request"
 showMessageType HistoryReplyMessage = "history_reply"
@@ -256,6 +260,8 @@ instance FromJSON MessageType where
       "input_reply"         -> return InputReplyMessage
       "comm_open"           -> return CommOpenMessage
       "comm_msg"            -> return CommDataMessage
+      "comm_info_request"   -> return CommInfoRequestMessage
+      "comm_info_reply"     -> return CommInfoReplyMessage
       "comm_close"          -> return CommCloseMessage
       "history_request"     -> return HistoryRequestMessage
       "history_reply"       -> return HistoryReplyMessage
@@ -293,6 +299,14 @@ data Message =
                  , implementation :: String -- ^ e.g. IHaskell
                  , implementationVersion :: String -- ^ The version of the implementation
                  , languageInfo :: LanguageInfo
+             |
+             -- | A request from a frontend for information about the comms.
+               CommInfoRequest { header :: MessageHeader }
+             |
+             -- | A response to a CommInfoRequest.
+               CommInfoReply
+                 { header   :: MessageHeader
+                 , commInfo :: [(String, String)] -- ^ A dictionary of the comms, indexed by uuids.
                  }
              |
              -- | A request from a frontend to execute some code.
@@ -519,6 +533,7 @@ replyType InspectRequestMessage = Just InspectReplyMessage
 replyType ShutdownRequestMessage = Just ShutdownReplyMessage
 replyType HistoryRequestMessage = Just HistoryReplyMessage
 replyType CommOpenMessage = Just CommDataMessage
+replyType CommInfoRequestMessage = Just CommInfoReplyMessage
 replyType _ = Nothing
 
 -- | Data for display: a string with associated MIME type.

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -263,6 +263,13 @@ replyTo _ KernelInfoRequest{} replyHeader state =
                 }
               })
 
+replyTo _ CommInfoRequest{} replyHeader state =
+  return
+    (state, CommInfoReply
+              { header = replyHeader
+              , commInfo = []
+              })
+
 -- Reply to a shutdown request by exiting the main thread. Before shutdown, reply to the request to
 -- let the frontend know shutdown is happening.
 replyTo interface ShutdownRequest { restartPending = restartPending } replyHeader _ = liftIO $ do

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -267,7 +267,7 @@ replyTo _ CommInfoRequest{} replyHeader state =
   return
     (state, CommInfoReply
               { header = replyHeader
-              , commInfo = []
+              , commInfo = mempty
               })
 
 -- Reply to a shutdown request by exiting the main thread. Before shutdown, reply to the request to

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -264,10 +264,11 @@ replyTo _ KernelInfoRequest{} replyHeader state =
               })
 
 replyTo _ CommInfoRequest{} replyHeader state =
+  let comms = Map.mapKeys (UUID.uuidToString) (openComms state) in
   return
     (state, CommInfoReply
               { header = replyHeader
-              , commInfo = mempty
+              , commInfo = Map.map (\(Widget w) -> targetName w) comms
               })
 
 -- Reply to a shutdown request by exiting the main thread. Before shutdown, reply to the request to


### PR DESCRIPTION
To fix #694.

This adds support for [`comm_info_request`](http://jupyter-client.readthedocs.io/en/latest/messaging.html#comm-info). I added `CommInfoRequest` and `CommInfoReply` Messages and all the Aeson bits for both. The `replyTo` functions are faked out for now with empty maps.

@vaibhavsagar says what's currently here is enough to fix his issue, but it would be better to actually respond with a list of open comms. :) I plan on doing that next. 