### PR TITLE
Work with GHC 8.2

### DIFF
--- a/ghc-parser/ghc-parser.cabal
+++ b/ghc-parser/ghc-parser.cabal
@@ -33,7 +33,7 @@ library
   -- other-modules:
   -- other-extensions:
   build-depends:       base                 >=4.6 && < 5,
-                       ghc                  >=7.6 && <8.1
+                       ghc                  >=7.6 && <8.3
 
   if   impl(ghc >= 7.6) && impl(ghc < 7.8)
     hs-source-dirs:      generic-src src-7.6

--- a/ihaskell-display/ihaskell-aeson/ihaskell-aeson.cabal
+++ b/ihaskell-display/ihaskell-aeson/ihaskell-aeson.cabal
@@ -53,7 +53,7 @@ library
   -- other-modules:       
              
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.6 && <4.10,
+  build-depends:       base >=4.6 && <4.11,
                        here,
                        text,
                        bytestring,

--- a/ihaskell-display/ihaskell-diagrams/ihaskell-diagrams.cabal
+++ b/ihaskell-display/ihaskell-diagrams/ihaskell-diagrams.cabal
@@ -54,7 +54,7 @@ library
   other-modules:       IHaskell.Display.Diagrams.Animation
   
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.6 && <4.10,
+  build-depends:       base >=4.6 && <4.11,
                        text,
                        bytestring,
                        directory,

--- a/ihaskell-display/ihaskell-gnuplot/ihaskell-gnuplot.cabal
+++ b/ihaskell-display/ihaskell-gnuplot/ihaskell-gnuplot.cabal
@@ -54,7 +54,7 @@ library
   -- other-modules:       
              
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.6 && <4.10,
+  build-depends:       base >=4.6 && <4.11,
                        bytestring,
                        gnuplot >= 0.5.4,
                        ihaskell >= 0.6.2

--- a/ihaskell-display/ihaskell-hatex/ihaskell-hatex.cabal
+++ b/ihaskell-display/ihaskell-hatex/ihaskell-hatex.cabal
@@ -14,7 +14,7 @@ cabal-version:       >=1.16
 
 library
   exposed-modules:     IHaskell.Display.Hatex
-  build-depends:       base >=4.6 && <4.10,
+  build-depends:       base >=4.6 && <4.11,
                        text,
                        HaTeX >= 3.9,
                        ihaskell >= 0.5

--- a/ihaskell-display/ihaskell-magic/ihaskell-magic.cabal
+++ b/ihaskell-display/ihaskell-magic/ihaskell-magic.cabal
@@ -57,7 +57,7 @@ library
   -- other-modules:       
              
   -- Other library packages from which modules are imported.
-  build-depends:       base >=4.6 && <4.10,
+  build-depends:       base >=4.6 && <4.11,
                        magic >= 1.0.8,
                        text,
                        bytestring,

--- a/ihaskell.cabal
+++ b/ihaskell.cabal
@@ -92,7 +92,7 @@ library
     build-depends:       bin-package-db
 
   if impl(ghc >= 8.0)
-    build-depends:     ghc-boot             >=8.0 && <8.1
+    build-depends:     ghc-boot             >=8.0 && <8.3
 
   exposed-modules: IHaskell.Display
                    IHaskell.Convert
@@ -134,7 +134,7 @@ executable ihaskell
   default-language:    Haskell2010
   build-depends:       
                        ihaskell -any,
-                       base                 >=4.6 && < 4.10,
+                       base                 >=4.6 && < 4.11,
                        text                 >=0.11,
                        transformers         -any,
                        ghc                  >=7.6 || < 7.11,

--- a/src/IHaskell/Eval/Completion.hs
+++ b/src/IHaskell/Eval/Completion.hs
@@ -29,7 +29,9 @@ import           Data.Maybe (fromJust)
 import           System.Environment (getEnv)
 
 import           GHC hiding (Qualified)
-#if MIN_VERSION_ghc(7,10,0)
+#if MIN_VERSION_ghc(8,2,0)
+import           GHC.PackageDb
+#elif MIN_VERSION_ghc(7,10,0)
 import           GHC.PackageDb (ExposedModule(exposedName))
 #endif
 import           DynFlags
@@ -61,6 +63,9 @@ data CompletionType = Empty
                     | KernelOption String
                     | Extension String
   deriving (Show, Eq)
+#if MIN_VERSION_ghc(8,2,0)
+exposedName = fst
+#endif
 #if MIN_VERSION_ghc(7,10,0)
 extName (FlagSpec { flagSpecName = name }) = name
 #else

--- a/src/IHaskell/Eval/Info.hs
+++ b/src/IHaskell/Eval/Info.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE NoImplicitPrelude, OverloadedStrings #-}
+{-# LANGUAGE CPP, NoImplicitPrelude, OverloadedStrings #-}
 
 {- | Description : Inspect type and function information and documentation.  -}
 module IHaskell.Eval.Info (info) where
@@ -19,7 +19,11 @@ import           Exception
 info :: String -> Interpreter String
 info name = ghandle handler $ do
   dflags <- getSessionDynFlags
+#if MIN_VERSION_ghc(8,2,0)
+  result <- exprType TM_Inst name
+#else
   result <- exprType name
+#endif
   return $ typeCleaner $ showPpr dflags result
   where
     handler :: SomeException -> Interpreter String

--- a/src/tests/IHaskell/Test/Eval.hs
+++ b/src/tests/IHaskell/Test/Eval.hs
@@ -159,6 +159,11 @@ testEval =
       "putStrLn \"Привет!\"" `becomes` ["Привет!"]
 
     it "evaluates directives" $ do
+#if MIN_VERSION_ghc(8,2,0)
+      -- It's `p` instead of `t` for some reason
+      ":typ 3" `becomes` ["3 :: forall p. Num p => p"]
+#else
       ":typ 3" `becomes` ["3 :: forall t. Num t => t"]
+#endif
       ":k Maybe" `becomes` ["Maybe :: * -> *"]
       ":in String" `pages` ["type String = [Char] \t-- Defined in \8216GHC.Base\8217"]


### PR DESCRIPTION
I'd like to support GHC 8.2 by the time the Stackage LTS package set including it is released. I've updated the package bounds and now I'm running into a GHC API change between <=8.0 and 8.2 where `extraPkgConfs` seems to have been removed and the order of the list it expects has reversed.

To check the current progress, run `nix-build release821.nix`.