### PR TITLE
Default binPkgDb to False

### DIFF
--- a/ihaskell.cabal
+++ b/ihaskell.cabal
@@ -47,7 +47,7 @@ data-files:
     html/logo-64x64.png
 
 flag binPkgDb
-  default:             True
+  default:             False
   description:         bin-package-db package needed (needed for GHC >= 7.10)
 
 library


### PR DESCRIPTION
`binPkgDb` only works for `GHC 7.10`.