### PR TITLE
Restore compatibility with GHC-7 / old Cabal environments.

### DIFF
--- a/ihaskell.cabal
+++ b/ihaskell.cabal
@@ -68,7 +68,7 @@ library
                        ghc-paths            >=0.1,
                        haskeline            -any,
                        hlint                >=1.9,
-                       haskell-src-exts     >=1.16,
+                       haskell-src-exts     >=1.18,
                        http-client          >= 0.4,
                        http-client-tls      >= 0.2,
                        mtl                  >=2.1,


### PR DESCRIPTION
Some of the changes done lately make the project compile _only_ with GHC-8, and only when there are no obsolete package-versions installed in the Cabal environment.

Here I adress these issues so IHaskell will also install on an old GHC-7.10 setup.