### PR TITLE
Properly un-support GHC-7 (and other old stuff)

### DIFF
--- a/ihaskell.cabal
+++ b/ihaskell.cabal
@@ -55,7 +55,7 @@ library
   default-language:    Haskell2010
   build-depends:
                        aeson                >=1.0,
-                       base                 >=4.6,
+                       base                 >=4.9,
                        base64-bytestring    >=1.0,
                        bytestring           >=0.10,
                        cereal               >=0.3,
@@ -63,7 +63,7 @@ library
                        containers           >=0.5,
                        directory            -any,
                        filepath             -any,
-                       ghc                  >=7.6,
+                       ghc                  >=8.0,
                        ghc-parser           >=0.1.7,
                        ghc-paths            >=0.1,
                        haskeline            -any,

--- a/ihaskell.cabal
+++ b/ihaskell.cabal
@@ -68,7 +68,7 @@ library
                        ghc-paths            >=0.1,
                        haskeline            -any,
                        hlint                >=1.9,
-                       haskell-src-exts     >=1.16,
+                       haskell-src-exts     >=1.18,
                        http-client          >= 0.4,
                        http-client-tls      >= 0.2,
                        mtl                  >=2.1,


### PR DESCRIPTION
In #716, it was decided to not waste effort on supporting GHC-7.

This PR adjusts the dependencies to make this clear when Cabal-compiling the project with older versions.

(But see also #747, for how GHC-7.10 _could_ still be supported.)