### PR TITLE
Add note about getting GHC 7.10 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 >
 > Alternatively, watch a [talk and demo](http://begriffs.com/posts/2016-01-20-ihaskell-notebook.html) showing off IHaskell features.
 
-IHaskell is a kernel for the [Jupyter project](http://ipython.org), which allows you to use Haskell inside Jupyter frontends (including the console and notebook). It currently supports GHC 8.
+IHaskell is a kernel for the [Jupyter project](http://ipython.org), which allows you to use Haskell inside Jupyter frontends (including the console and notebook). It currently supports GHC 8. For GHC 7.10 support please use the [`GHC7`](https://github.com/gibiansky/IHaskell/releases/tag/GHC7) tag.
 
 For a tour of some IHaskell features, check out the [demo Notebook](http://nbviewer.ipython.org/github/gibiansky/IHaskell/blob/master/notebooks/IHaskell.ipynb). More example notebooks are available on the [wiki](https://github.com/gibiansky/IHaskell/wiki).
 The [wiki](https://github.com/gibiansky/IHaskell/wiki) also has more extensive documentation of IHaskell features.


### PR DESCRIPTION
@leftaroundabout is this the `README` change you wanted? It's more accurate to say 7.6-7.10 support but I don't know anyone who is depending on IHaskell supporting those older versions of GHC.