### PR TITLE
Make silent and store_hitsory optional params

### DIFF
--- a/ipython-kernel/src/IHaskell/IPython/Message/Parser.hs
+++ b/ipython-kernel/src/IHaskell/IPython/Message/Parser.hs
@@ -125,9 +125,10 @@ executeInputParser = requestParser $ \obj -> do
 executeRequestParser :: LByteString -> Message
 executeRequestParser content =
   let parser obj = do
+                     let getOrElse a k = (fromMaybe a) <$> obj .:? k
                      code <- obj .: "code"
-                     silent <- obj .: "silent"
-                     storeHistory <- obj .: "store_history"
+                     silent <- getOrElse False "silent"
+                     storeHistory <- getOrElse (not silent) "store_history"
                      allowStdin <- obj .: "allow_stdin"
 
                      return (code, silent, storeHistory, allowStdin)


### PR DESCRIPTION
According to the [Jupyter messaging protocol](http://jupyter-client.readthedocs.io/en/latest/messaging.html#execute), `silent` and `store_history` should be optional parameters.  

`silent` should default to `False` while `store_history` should default to the opposite of `silent`.