### PR TITLE
Don't include display modules by default when building with Nix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -204,7 +204,23 @@ matrix:
         - export NIX_CONF_DIR=~
         - echo "binary-caches = http://128.199.234.106:3000" >> $NIX_CONF_DIR/nix.conf
         - echo "binary-cache-public-keys = 128.199.234.106:jzUyrIQHov5i6f94jQVriqPDLuPYlZPAsga3W3k+L8E=" >> $NIX_CONF_DIR/nix.conf
-      script: nix-build -I nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/a0b50eab599005127476e7b3b4ae8bd2d363091b.tar.gz $RELEASE_NIX
+      script:
+        - >
+          nix-build
+          -I nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/a0b50eab599005127476e7b3b4ae8bd2d363091b.tar.gz
+          $RELEASE_NIX
+          --arg packages '(p: with p; [
+            ihaskell-aeson
+            ihaskell-blaze
+            ihaskell-charts
+            ihaskell-diagrams
+            ihaskell-gnuplot
+            ihaskell-hatex
+            ihaskell-juicypixels
+            ihaskell-magic
+            ihaskell-plot
+            ihaskell-static-canvas
+          ])'
     - language: nix
       env: RELEASE_NIX="release-8.2.nix"
       cache:
@@ -214,4 +230,20 @@ matrix:
         - export NIX_CONF_DIR=~
         - echo "binary-caches = http://128.199.234.106:3000" >> $NIX_CONF_DIR/nix.conf
         - echo "binary-cache-public-keys = 128.199.234.106:jzUyrIQHov5i6f94jQVriqPDLuPYlZPAsga3W3k+L8E=" >> $NIX_CONF_DIR/nix.conf
-      script: nix-build -I nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/a0b50eab599005127476e7b3b4ae8bd2d363091b.tar.gz $RELEASE_NIX
+      script:
+        - >
+          nix-build
+          -I nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/a0b50eab599005127476e7b3b4ae8bd2d363091b.tar.gz
+          $RELEASE_NIX
+          --arg packages '(p: with p; [
+            ihaskell-aeson
+            ihaskell-blaze
+            ihaskell-charts
+            ihaskell-diagrams
+            ihaskell-gnuplot
+            ihaskell-hatex
+            ihaskell-juicypixels
+            ihaskell-magic
+            ihaskell-plot
+            ihaskell-static-canvas
+          ])'

--- a/release-8.2.nix
+++ b/release-8.2.nix
@@ -107,21 +107,7 @@ let
     } // displays self;
   };
   ihaskell = haskellPackages.ihaskell;
-  ihaskellEnv = haskellPackages.ghcWithPackages (self: with self; [
-    ihaskell
-    ihaskell-aeson
-    ihaskell-blaze
-    ihaskell-charts
-    ihaskell-diagrams
-    ihaskell-gnuplot
-    ihaskell-hatex
-    ihaskell-juicypixels
-    ihaskell-magic
-    ihaskell-plot
-    # ihaskell-rlangqq
-    ihaskell-static-canvas
-    # ihaskell-widgets
-  ] ++ packages self);
+  ihaskellEnv = haskellPackages.ghcWithPackages (self: [ self.ihaskell ] ++ packages self);
   jupyter = nixpkgs.python3.withPackages (ps: [ ps.jupyter ps.notebook ]);
   ihaskellSh = nixpkgs.writeScriptBin "ihaskell-notebook" ''
     #! ${nixpkgs.stdenv.shell}

--- a/release.nix
+++ b/release.nix
@@ -64,21 +64,7 @@ let
     } // displays self;
   };
   ihaskell = haskellPackages.ihaskell;
-  ihaskellEnv = haskellPackages.ghcWithPackages (self: with self; [
-    ihaskell
-    ihaskell-aeson
-    ihaskell-blaze
-    ihaskell-charts
-    ihaskell-diagrams
-    ihaskell-gnuplot
-    ihaskell-hatex
-    ihaskell-juicypixels
-    ihaskell-magic
-    ihaskell-plot
-    # ihaskell-rlangqq
-    ihaskell-static-canvas
-    # ihaskell-widgets
-  ] ++ packages self);
+  ihaskellEnv = haskellPackages.ghcWithPackages (self: [ self.ihaskell ] ++ packages self);
   jupyter = nixpkgs.python3.withPackages (ps: [ ps.jupyter ps.notebook ]);
   ihaskellSh = nixpkgs.writeScriptBin "ihaskell-notebook" ''
     #! ${nixpkgs.stdenv.shell}


### PR DESCRIPTION
I think we should continue to test with `ihaskell-*` to make sure they build correctly, but providing it out of the box makes for an unnecessarily large install for features that most users don't want/need.