### PR TITLE
Ignore 'Unnecessary hiding'

### DIFF
--- a/src/IHaskell/Eval/Lint.hs
+++ b/src/IHaskell/Eval/Lint.hs
@@ -61,7 +61,7 @@ lint blocks = do
   -- Initialize hlint settings
   initialized <- not <$> isEmptyMVar hlintSettings
   unless initialized $
-    autoSettings >>= putMVar hlintSettings
+    autoSettings' >>= putMVar hlintSettings
 
   -- Get hlint settings
   (flags, classify, hint) <- readMVar hlintSettings
@@ -76,6 +76,11 @@ lint blocks = do
     if null suggestions
       then []
       else [plain $ concatMap plainSuggestion suggestions, html $ htmlSuggestions suggestions]
+  where
+    autoSettings' = do
+      (fixities, classify, hints) <- autoSettings
+      let hidingIgnore = Classify Ignore "Unnecessary hiding" "" ""
+      return (fixities, hidingIgnore:classify, hints)
 
 showIdea :: Idea -> Maybe LintSuggestion
 showIdea idea =

--- a/src/IHaskell/Eval/Lint.hs
+++ b/src/IHaskell/Eval/Lint.hs
@@ -70,7 +70,7 @@ lint blocks = do
   -- create 'suggestions'
   let modules = mapMaybe (createModule mode) blocks
       ideas = applyHints classify hint (map (\m -> (m, [])) modules)
-      suggestions = mapMaybe showIdea ideas
+      suggestions = mapMaybe showIdea $ filter (not . ignoredIdea) ideas
 
   return $ Display $
     if null suggestions
@@ -81,6 +81,7 @@ lint blocks = do
       (fixities, classify, hints) <- autoSettings
       let hidingIgnore = Classify Ignore "Unnecessary hiding" "" ""
       return (fixities, hidingIgnore:classify, hints)
+    ignoredIdea idea = ideaSeverity idea == Ignore
 
 showIdea :: Idea -> Maybe LintSuggestion
 showIdea idea =


### PR DESCRIPTION
The new 'Unnecessary hiding' warning in HLint 2.0.10 is throwing up false positives on the example notebook. I also think it doesn't make much sense in an interactive notebook setting, because e.g. modules can be imported selectively in one cell and used in another, which HLint isn't equipped to handle.