### PR TITLE
Bump resolvers to lts-9.12

### DIFF
--- a/ihaskell-display/ihaskell-aeson/stack.yaml
+++ b/ihaskell-display/ihaskell-aeson/stack.yaml
@@ -1,4 +1,4 @@
 flags: {}
 packages:
 - '.'
-resolver: lts-9.11
+resolver: lts-9.12

--- a/ihaskell-display/ihaskell-blaze/stack.yaml
+++ b/ihaskell-display/ihaskell-blaze/stack.yaml
@@ -1,4 +1,4 @@
 flags: {}
 packages:
 - '.'
-resolver: lts-9.11
+resolver: lts-9.12

--- a/ihaskell-display/ihaskell-charts/stack.yaml
+++ b/ihaskell-display/ihaskell-charts/stack.yaml
@@ -1,4 +1,4 @@
 flags: {}
 packages:
 - '.'
-resolver: lts-9.11
+resolver: lts-9.12

--- a/ihaskell-display/ihaskell-diagrams/stack.yaml
+++ b/ihaskell-display/ihaskell-diagrams/stack.yaml
@@ -1,4 +1,4 @@
 flags: {}
 packages:
 - '.'
-resolver: lts-9.11
+resolver: lts-9.12

--- a/ihaskell-display/ihaskell-gnuplot/stack.yaml
+++ b/ihaskell-display/ihaskell-gnuplot/stack.yaml
@@ -1,5 +1,5 @@
 flags: {}
 packages:
 - '.'
-resolver: lts-9.11
+resolver: lts-9.12
 extra-deps: []

--- a/ihaskell-display/ihaskell-hatex/stack.yaml
+++ b/ihaskell-display/ihaskell-hatex/stack.yaml
@@ -1,4 +1,4 @@
 flags: {}
 packages:
 - '.'
-resolver: lts-9.11
+resolver: lts-9.12

--- a/ihaskell-display/ihaskell-juicypixels/stack.yaml
+++ b/ihaskell-display/ihaskell-juicypixels/stack.yaml
@@ -1,4 +1,4 @@
 flags: {}
 packages:
 - '.'
-resolver: lts-9.11
+resolver: lts-9.12

--- a/ihaskell-display/ihaskell-magic/stack.yaml
+++ b/ihaskell-display/ihaskell-magic/stack.yaml
@@ -1,4 +1,4 @@
 flags: {}
 packages:
 - '.'
-resolver: lts-9.11
+resolver: lts-9.12

--- a/ihaskell-display/ihaskell-plot/stack.yaml
+++ b/ihaskell-display/ihaskell-plot/stack.yaml
@@ -1,4 +1,4 @@
 flags: {}
 packages:
 - '.'
-resolver: lts-9.11
+resolver: lts-9.12

--- a/ihaskell-display/ihaskell-rlangqq/stack.yaml
+++ b/ihaskell-display/ihaskell-rlangqq/stack.yaml
@@ -1,4 +1,4 @@
 flags: {}
 packages:
 - '.'
-resolver: lts-9.11
+resolver: lts-9.12

--- a/ihaskell-display/ihaskell-static-canvas/stack.yaml
+++ b/ihaskell-display/ihaskell-static-canvas/stack.yaml
@@ -1,4 +1,4 @@
 flags: {}
 packages:
 - '.'
-resolver: lts-9.11
+resolver: lts-9.12

--- a/ihaskell-display/ihaskell-widgets/stack.yaml
+++ b/ihaskell-display/ihaskell-widgets/stack.yaml
@@ -1,4 +1,4 @@
 flags: {}
 packages:
 - '.'
-resolver: lts-9.11
+resolver: lts-9.12

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,7 +14,7 @@ packages:
     - ./ihaskell-display/ihaskell-plot
     - ./ihaskell-display/ihaskell-static-canvas
     - ./ihaskell-display/ihaskell-widgets
-resolver: lts-9.11
+resolver: lts-9.12
 extra-deps: []
 flags:
   ihaskell:


### PR DESCRIPTION
After #777 I don't expect any test failures due to the new HLint.