### PR TITLE
release-8.2.nix: use GHC 8.2.2

### DIFF
--- a/release-8.2.nix
+++ b/release-8.2.nix
@@ -47,7 +47,7 @@ let
         "ihaskell-static-canvas"
         "ihaskell-widgets"
       ]);
-  haskellPackages = nixpkgs.haskell.packages.ghc821.override {
+  haskellPackages = nixpkgs.haskell.packages.ghc822.override {
     overrides = self: super: {
       ihaskell          = nixpkgs.haskell.lib.overrideCabal (
                           self.callCabal2nix "ihaskell" ihaskell-src {}) (_drv: {


### PR DESCRIPTION
It is now available in `nixos-17.09`.