### PR TITLE
Build 'jupyter console' wrappers with nix installation

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -65,11 +65,11 @@ let
   };
   ihaskellEnv = haskellPackages.ghcWithPackages (self: [ self.ihaskell ] ++ packages self);
   jupyter = nixpkgs.python3.withPackages (ps: [ ps.jupyter ps.notebook ]);
-  ihaskellSh = cmd: nixpkgs.writeScriptBin "ihaskell-${cmd}" ''
+  ihaskellSh = cmd: extraArgs: nixpkgs.writeScriptBin "ihaskell-${cmd}" ''
     #! ${nixpkgs.stdenv.shell}
     export GHC_PACKAGE_PATH="$(echo ${ihaskellEnv}/lib/*/package.conf.d| tr ' ' ':'):$GHC_PACKAGE_PATH"
     export PATH="${nixpkgs.stdenv.lib.makeBinPath ([ ihaskellEnv jupyter ] ++ systemPackages nixpkgs)}"
-    ${ihaskellEnv}/bin/ihaskell install -l $(${ihaskellEnv}/bin/ghc --print-libdir) --use-rtsopts="${rtsopts}" && ${jupyter}/bin/jupyter ${cmd} "$@"
+    ${ihaskellEnv}/bin/ihaskell install -l $(${ihaskellEnv}/bin/ghc --print-libdir) --use-rtsopts="${rtsopts}" && ${jupyter}/bin/jupyter ${cmd} ${extraArgs} "$@"
   '';
 in
 nixpkgs.buildEnv {
@@ -77,8 +77,9 @@ nixpkgs.buildEnv {
   buildInputs = [ nixpkgs.makeWrapper ];
   paths = [ ihaskellEnv jupyter ];
   postBuild = ''
-    ln -s ${ihaskellSh "notebook"}/bin/ihaskell-notebook $out/bin/
-    ln -s ${ihaskellSh "nbconvert"}/bin/ihaskell-nbconvert $out/bin/
+    ln -s ${ihaskellSh "notebook" ""}/bin/ihaskell-notebook $out/bin/
+    ln -s ${ihaskellSh "nbconvert" ""}/bin/ihaskell-nbconvert $out/bin/
+    ln -s ${ihaskellSh "console" "--kernel=haskell"}/bin/ihaskell-console $out/bin/
     for prg in $out/bin"/"*;do
       if [[ -f $prg && -x $prg ]]; then
         wrapProgram $prg --set PYTHONPATH "$(echo ${jupyter}/lib/*/site-packages)"


### PR DESCRIPTION
For those of us that prefer the console version of jupyter.
This adds `ihaskell-console` which runs `jupyter console --kernel=haskell`.


On an unrelated note, any plans to make a release anytime in the near future?
I'd like to have ihaskell available in nixpkgs but the last release is a couple of years old.