### PR TITLE
(Idiomatically) customise size of diagrams shown in notebooks

### DIFF
--- a/ihaskell-display/ihaskell-diagrams/IHaskell/Display/Diagrams.hs
+++ b/ihaskell-display/ihaskell-diagrams/IHaskell/Display/Diagrams.hs
@@ -62,8 +62,12 @@ withSizeSpec spec renderable = ManuallySized renderable imgWidth imgHeight
          V2 (Just w) (Just h) -> (w, h)
          V2 (Just w) Nothing  -> (w, w/aspect)
          V2 Nothing (Just h)  -> (aspect*h, h)
-         V2 Nothing Nothing   -> (aspect*defaultHeight, defaultHeight)
-       defaultHeight = 300
+         V2 Nothing Nothing   -> (defaultDiagonal / sqrt (1 + aspect^2)) *^ (aspect, 1)
+                                 -- w^2 + h^2 = defaultDiagonal^2 / (1+aspect^2)
+                                 --                * (aspect^2 + 1)
+                                 --           = defaultDiagonal^2
+                                 -- w/h = aspect/1 = aspect
+       defaultDiagonal = 500
 
 withImgWidth :: Int -> Diagram Cairo -> ManuallySized (Diagram Cairo)
 withImgWidth imgWidth = withSizeSpec $ mkSizeSpec2D (Just $ fromIntegral imgWidth)

--- a/ihaskell-display/ihaskell-diagrams/IHaskell/Display/Diagrams.hs
+++ b/ihaskell-display/ihaskell-diagrams/IHaskell/Display/Diagrams.hs
@@ -1,6 +1,10 @@
 {-# LANGUAGE TypeSynonymInstances, FlexibleInstances #-}
+{-# LANGUAGE DeriveFunctor, DeriveGeneric #-}
 
-module IHaskell.Display.Diagrams (diagram, animation, imgHeight) where
+module IHaskell.Display.Diagrams
+         ( diagram, animation
+         , ManuallySized, withSizeSpec, withImgWidth, withImgHeight
+         ) where
 
 import qualified Data.ByteString.Char8 as Char
 import           System.Directory
@@ -11,37 +15,34 @@ import           Diagrams.Prelude
 import           IHaskell.Display
 import           IHaskell.Display.Diagrams.Animation
 
-instance IHaskellDisplay (QDiagram Cairo V2 Double Any) where
+import           GHC.Generics (Generic)
+
+data ManuallySized a = ManuallySized
+    { contentToDisplay :: a
+    , imgManualWidth :: Double
+    , imgManualHeight :: Double
+    } deriving (Show, Functor, Generic)
+
+instance IHaskellDisplay (ManuallySized (QDiagram Cairo V2 Double Any)) where
   display renderable = do
     png <- diagramData renderable PNG
     svg <- diagramData renderable SVG
     return $ Display [png, svg]
 
-{-# NOINLINE imgHeight #-}
-imgHeight :: IORef Double
-imgHeight = unsafePerformIO (newIORef 300)
-
-diagramData :: Diagram Cairo -> OutputType -> IO DisplayData
-diagramData renderable format = do
+diagramData :: ManuallySized (Diagram Cairo) -> OutputType -> IO DisplayData
+diagramData (ManuallySized renderable imgWidth imgHeight) format = do
   switchToTmpDir
-
-  imgHeight' <- readIORef imgHeight
-
-  -- Compute width and height.
-  let w = width renderable
-      h = height renderable
-      aspect = w / h
-      imgWidth = aspect * imgHeight'
 
   -- Write the image.
   let filename = ".ihaskell-diagram." ++ extension format
-  renderCairo filename (mkSizeSpec2D (Just imgWidth) (Just imgHeight')) renderable
+  renderCairo filename (mkSizeSpec2D (Just imgWidth)
+                                     (Just imgHeight)) renderable
 
   -- Convert to base64.
   imgData <- Char.readFile filename
   let value =
         case format of
-          PNG -> png (floor imgWidth) (floor imgHeight') $ base64 imgData
+          PNG -> png (floor imgWidth) (floor imgHeight) $ base64 imgData
           SVG -> svg (Char.unpack imgData)
 
   return value
@@ -53,3 +54,24 @@ diagramData renderable format = do
 -- Rendering hint.
 diagram :: Diagram Cairo -> Diagram Cairo
 diagram = id
+
+withSizeSpec :: SizeSpec V2 Double -> Diagram Cairo -> ManuallySized (Diagram Cairo)
+withSizeSpec spec renderable = ManuallySized renderable imgWidth imgHeight
+ where aspect = width renderable / height renderable
+       (imgWidth, imgHeight) = case getSpec spec of
+         V2 (Just w) (Just h) -> (w, h)
+         V2 (Just w) Nothing  -> (w, w/aspect)
+         V2 Nothing (Just h)  -> (aspect*h, h)
+         V2 Nothing Nothing   -> (aspect*defaultHeight, defaultHeight)
+       defaultHeight = 300
+
+withImgWidth :: Int -> Diagram Cairo -> ManuallySized (Diagram Cairo)
+withImgWidth imgWidth = withSizeSpec $ mkSizeSpec2D (Just $ fromIntegral imgWidth)
+                                                    Nothing
+
+withImgHeight :: Int -> Diagram Cairo -> ManuallySized (Diagram Cairo)
+withImgHeight imgHeight = withSizeSpec $ mkSizeSpec2D Nothing
+                                                      (Just $ fromIntegral imgHeight)
+
+instance IHaskellDisplay (QDiagram Cairo V2 Double Any) where
+  display = display . withSizeSpec (mkSizeSpec2D Nothing Nothing)

--- a/ihaskell-display/ihaskell-diagrams/IHaskell/Display/Diagrams.hs
+++ b/ihaskell-display/ihaskell-diagrams/IHaskell/Display/Diagrams.hs
@@ -58,11 +58,12 @@ diagram = id
 withSizeSpec :: SizeSpec V2 Double -> Diagram Cairo -> ManuallySized (Diagram Cairo)
 withSizeSpec spec renderable = ManuallySized renderable imgWidth imgHeight
  where aspect = width renderable / height renderable
-       (imgWidth, imgHeight) = case getSpec spec of
-         V2 (Just w) (Just h) -> (w, h)
-         V2 (Just w) Nothing  -> (w, w/aspect)
-         V2 Nothing (Just h)  -> (aspect*h, h)
-         V2 Nothing Nothing   -> (defaultDiagonal / sqrt (1 + aspect^2)) *^ (aspect, 1)
+       V2 imgWidth imgHeight = case getSpec spec of
+         V2 (Just w) (Just h) -> V2 w h
+         V2 (Just w) Nothing  -> V2 w (w/aspect)
+         V2 Nothing (Just h)  -> V2 (aspect*h) h
+         V2 Nothing Nothing   -> (defaultDiagonal / sqrt (1 + aspect^2))
+                                    *^ V2 aspect 1
                                  -- w^2 + h^2 = defaultDiagonal^2 / (1+aspect^2)
                                  --                * (aspect^2 + 1)
                                  --           = defaultDiagonal^2


### PR DESCRIPTION
1f852097f9cd373a31fc5d94b28ede12352dd401 exposed an `IORef` that could be modified in order to tweak the size at which diagrams are rendered for display. This works, but it seems very un-Haskellish and also isn't very flexible when other properties than the height should be fixed.

This PR takes an alternative approach: it offers a new type that wraps a size specification with a diagram. This way, it can be tweaked in a declarative way. Also, I've changed the default behaviour: previously, the _height_ would get fixed to 300. But this is problematic when displaying diagrams of different aspect ratios, in particular, diagrams with small height used to get stretched extremely wide.

Example of the new behaviour: http://nbviewer.jupyter.org/gist/leftaroundabout/ee800328d4cda035955878dd680e677b
