### PR TITLE
new jupyterlab mime types

### DIFF
--- a/ipython-kernel/src/IHaskell/IPython/Message/Writer.hs
+++ b/ipython-kernel/src/IHaskell/IPython/Message/Writer.hs
@@ -8,11 +8,14 @@ module IHaskell.IPython.Message.Writer (ToJSON(..)) where
 
 import           Data.Aeson
 import           Data.Aeson.Types (Pair)
+import           Data.Aeson.Parser (json)
 import           Data.Map (Map)
 import           Data.Monoid (mempty)
 import           Data.Text (Text, pack)
+import           Data.Text.Encoding (encodeUtf8)
 import qualified Data.Map               as Map
 import           IHaskell.IPython.Types
+import           Data.Maybe (fromMaybe)
 
 instance ToJSON LanguageInfo where
   toJSON info = object
@@ -173,6 +176,12 @@ instance ToJSON StreamType where
 
 -- | Convert a MIME type and value into a JSON dictionary pair.
 displayDataToJson :: DisplayData -> (Text, Value)
+displayDataToJson (DisplayData MimeJson dataStr) = 
+    pack (show MimeJson) .= fromMaybe (String "") (decodeStrict (encodeUtf8 dataStr) :: Maybe Value)
+displayDataToJson (DisplayData MimeVegalite dataStr) = 
+    pack (show MimeVegalite) .= fromMaybe (String "") (decodeStrict (encodeUtf8 dataStr) :: Maybe Value)
+displayDataToJson (DisplayData MimeVega dataStr) = 
+    pack (show MimeVega) .= fromMaybe (String "") (decodeStrict (encodeUtf8 dataStr) :: Maybe Value)
 displayDataToJson (DisplayData mimeType dataStr) =
   pack (show mimeType) .= String dataStr
 

--- a/ipython-kernel/src/IHaskell/IPython/Types.hs
+++ b/ipython-kernel/src/IHaskell/IPython/Types.hs
@@ -599,7 +599,7 @@ instance Show MimeType where
   show MimeJavascript = "application/javascript"
   show MimeJson = "application/json"
   show MimeVega = "application/vnd.vega.v2+json"
-  show MimeVegalite = "application/vnd.vegalite.v1+json"
+  show MimeVegalite = "application/vnd.vegalite.v2+json"
   show MimeVdom = "application/vdom.v1+json"
 
 instance Read MimeType where

--- a/ipython-kernel/src/IHaskell/IPython/Types.hs
+++ b/ipython-kernel/src/IHaskell/IPython/Types.hs
@@ -563,11 +563,18 @@ type Height = Int
 
 data MimeType = PlainText
               | MimeHtml
+              | MimeBmp Width Height
               | MimePng Width Height
               | MimeJpg Width Height
+              | MimeGif Width Height
               | MimeSvg
               | MimeLatex
+              | MimeMarkdown
               | MimeJavascript
+              | MimeJson
+              | MimeVega
+              | MimeVegalite
+              | MimeVdom
   deriving (Eq, Typeable, Generic)
 
 -- Extract the plain text from a list of displays.
@@ -582,17 +589,31 @@ extractPlain disps =
 instance Show MimeType where
   show PlainText = "text/plain"
   show MimeHtml = "text/html"
+  show (MimeBmp _ _) = "image/bmp"
   show (MimePng _ _) = "image/png"
   show (MimeJpg _ _) = "image/jpeg"
+  show (MimeGif _ _) = "image/gif"
   show MimeSvg = "image/svg+xml"
   show MimeLatex = "text/latex"
+  show MimeMarkdown = "text/markdown"
   show MimeJavascript = "application/javascript"
+  show MimeJson = "application/json"
+  show MimeVega = "application/vnd.vega.v2+json"
+  show MimeVegalite = "application/vnd.vegalite.v1+json"
+  show MimeVdom = "application/vdom.v1+json"
 
 instance Read MimeType where
   readsPrec _ "text/plain" = [(PlainText, "")]
   readsPrec _ "text/html" = [(MimeHtml, "")]
+  readsPrec _ "image/bmp" = [(MimeBmp 50 50, "")]
   readsPrec _ "image/png" = [(MimePng 50 50, "")]
   readsPrec _ "image/jpg" = [(MimeJpg 50 50, "")]
+  readsPrec _ "image/gif" = [(MimeGif 50 50, "")]
   readsPrec _ "image/svg+xml" = [(MimeSvg, "")]
   readsPrec _ "text/latex" = [(MimeLatex, "")]
+  readsPrec _ "text/markdown" = [(MimeMarkdown, "")]
   readsPrec _ "application/javascript" = [(MimeJavascript, "")]
+  readsPrec _ "application/json" = [(MimeJson, "")]
+  readsPrec _ "application/vnd.vega.v2+json" = [(MimeVega, "")]
+  readsPrec _ "application/vnd.vegalite.v1+json" = [(MimeVegalite, "")]
+  readsPrec _ "application/vdom.v1+json" = [(MimeVdom, "")]

--- a/src/IHaskell/Display.hs
+++ b/src/IHaskell/Display.hs
@@ -25,11 +25,18 @@ module IHaskell.Display (
     -- * Constructors for displays
     plain,
     html,
+    bmp,
     png,
     jpg,
+    gif,
     svg,
     latex,
+    markdown,
     javascript,
+    json,
+    vega,
+    vegalite,
+    vdom,
     many,
 
     -- ** Image and data encoding functions
@@ -118,6 +125,38 @@ latex = DisplayData MimeLatex . T.pack
 -- | Generate a Javascript display.
 javascript :: String -> DisplayData
 javascript = DisplayData MimeJavascript . T.pack
+
+-- | Generate a Json display.
+json :: String -> DisplayData
+json = DisplayData MimeJson . T.pack
+
+-- | Generate a Vega display.
+vega :: String -> DisplayData
+vega = DisplayData MimeVega . T.pack
+
+-- | Generate a Vegalite display.
+vegalite :: String -> DisplayData
+vegalite = DisplayData MimeVegalite . T.pack
+
+-- | Generate a Vdom display.
+vdom :: String -> DisplayData
+vdom = DisplayData MimeVdom . T.pack
+
+-- | Generate a Markdown display.
+markdown :: String -> DisplayData
+markdown = DisplayData MimeMarkdown . T.pack
+
+-- | Generate a GIF display of the given width and height. Data must be provided in a Base64 encoded
+-- manner, suitable for embedding into HTML. The @base64@ function may be used to encode data into
+-- this format.
+gif :: Width -> Height -> Base64 -> DisplayData
+gif width height = DisplayData (MimeGif width height)
+
+-- | Generate a BMP display of the given width and height. Data must be provided in a Base64 encoded
+-- manner, suitable for embedding into HTML. The @base64@ function may be used to encode data into
+-- this format.
+bmp :: Width -> Height -> Base64 -> DisplayData
+bmp width height = DisplayData (MimeBmp width height)
 
 -- | Generate a PNG display of the given width and height. Data must be provided in a Base64 encoded
 -- manner, suitable for embedding into HTML. The @base64@ function may be used to encode data into


### PR DESCRIPTION
jupyterlab has bmp/gif/markdown/json/vega/vegalite/pdf mimetypes that can be used.