### PR TITLE
updated version numbers

### DIFF
--- a/ihaskell.cabal
+++ b/ihaskell.cabal
@@ -7,7 +7,7 @@ name:                ihaskell
 -- PVP summary:      +-+------- breaking API changes
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
-version:             0.9.0.3
+version:             0.9.1.0
 
 -- A short (one-line) description of the package.
 synopsis:            A Haskell backend kernel for the IPython project.
@@ -87,7 +87,7 @@ library
                        utf8-string          -any,
                        uuid                 >=1.3,
                        vector               -any,
-                       ipython-kernel       >=0.8.4
+                       ipython-kernel       >=0.9.1
   if flag(binPkgDb)
     build-depends:       bin-package-db
 

--- a/ipython-kernel/ipython-kernel.cabal
+++ b/ipython-kernel/ipython-kernel.cabal
@@ -1,5 +1,5 @@
 name:                ipython-kernel
-version:             0.9.0.2
+version:             0.9.1.0
 synopsis:            A library for creating kernels for IPython frontends
 
 description:         ipython-kernel is a library for communicating with frontends for the interactive IPython framework. It is used extensively in IHaskell, the interactive Haskell environment.


### PR DESCRIPTION
the IHaskell package (uses new mime types) depends on the new ipython-kernel (defines the Mime types). The version numbers need to be adopted. I think this should be it, but can you check it @vaibhavsagar ?