### PR TITLE
ihaskell-widgets: Make it compile with ghc 8.4

### DIFF
--- a/ihaskell-display/ihaskell-widgets/ihaskell-widgets.cabal
+++ b/ihaskell-display/ihaskell-widgets/ihaskell-widgets.cabal
@@ -97,7 +97,7 @@ library
                      , ipython-kernel >= 0.6.1.2
                      , text >= 0.11
                      , unordered-containers -any
-                     , vinyl >= 0.5
+                     , vinyl >= 0.5 && < 0.9
                      , vector -any
                      , scientific -any
                      , unix -any

--- a/ihaskell-display/ihaskell-widgets/src/IHaskell/Display/Widgets/Singletons.hs
+++ b/ihaskell-display/ihaskell-widgets/src/IHaskell/Display/Widgets/Singletons.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE EmptyCase #-}
 
 module IHaskell.Display.Widgets.Singletons where
 
@@ -16,7 +17,7 @@ import           Data.Singletons.Prelude.Ord
 -- Widget properties
 singletons
   [d|
-   
+
   data Field = ViewModule
              | ViewName
              | ModelModule

--- a/ihaskell-display/ihaskell-widgets/src/IHaskell/Display/Widgets/Types.hs
+++ b/ihaskell-display/ihaskell-widgets/src/IHaskell/Display/Widgets/Types.hs
@@ -14,6 +14,7 @@
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE AutoDeriveTypeable #-}
+{-# LANGUAGE CPP #-}
 
 -- | This module houses all the type-trickery needed to make widgets happen.
 --
@@ -79,7 +80,12 @@ import           Data.Vinyl.Functor (Compose(..), Const(..))
 import           Data.Vinyl.Lens (rget, rput, type (∈))
 import           Data.Vinyl.TypeLevel (RecAll)
 
+#if MIN_VERSION_singletons(2,4,0)
+import           Data.Singletons.Prelude.List
+#else
 import           Data.Singletons.Prelude ((:++))
+#endif
+
 import           Data.Singletons.TH
 
 import           GHC.IO.Exception
@@ -91,6 +97,16 @@ import           IHaskell.IPython.Message.UUID
 import           IHaskell.Display.Widgets.Singletons (Field, SField)
 import qualified IHaskell.Display.Widgets.Singletons as S
 import           IHaskell.Display.Widgets.Common
+
+#if MIN_VERSION_singletons(2,4,0)
+-- Versions of the "singletons" package are tightly tied to the GHC version.
+-- Singletons versions 2.3.* and earlier used the type level operator ':++'
+-- for appending type level lists while 2.4.* and latter use the normal value
+-- level list append operator '++'.
+-- To maintain compatibility across GHC versions we keep using the ':++'
+-- operator for now.
+type (a :++ b) = a ++ b
+#endif
 
 -- Classes from IPython's widget hierarchy. Defined as such to reduce code duplication.
 type WidgetClass = '[S.ViewModule, S.ViewName, S.ModelModule, S.ModelName,

--- a/stack-8.4.yaml
+++ b/stack-8.4.yaml
@@ -1,3 +1,5 @@
+resolver: lts-12.8
+
 flags: {}
 packages:
     - .
@@ -5,18 +7,21 @@ packages:
     - ./ghc-parser
     - ./ihaskell-display/ihaskell-aeson
     - ./ihaskell-display/ihaskell-blaze
-    # - ./ihaskell-display/ihaskell-charts
-    # - ./ihaskell-display/ihaskell-diagrams
+    - ./ihaskell-display/ihaskell-charts
+    - ./ihaskell-display/ihaskell-diagrams
     - ./ihaskell-display/ihaskell-gnuplot
     - ./ihaskell-display/ihaskell-hatex
     - ./ihaskell-display/ihaskell-juicypixels
     - ./ihaskell-display/ihaskell-magic
-    # - ./ihaskell-display/ihaskell-plot
+    - ./ihaskell-display/ihaskell-plot
     - ./ihaskell-display/ihaskell-static-canvas
-    # - ./ihaskell-display/ihaskell-widgets
-resolver: lts-12.8
+    - ./ihaskell-display/ihaskell-widgets
+
 extra-deps:
 - magic-1.1
+- Chart-1.9
+- Chart-cairo-1.9
+- plot-0.2.3.9
 
 nix:
   enable: false


### PR DESCRIPTION
GHC 8.4 allows value level operators (in this case list append, '++') to
be used at the type level, so that the singletons package for GHC 8.4
uses this operator whereas previous versions of singletons defined a ':++'
operator for type level append.