### PR TITLE
Remove conversion of svg to html for generic usage.

### DIFF
--- a/src/IHaskell/Publish.hs
+++ b/src/IHaskell/Publish.hs
@@ -6,7 +6,6 @@ module IHaskell.Publish
 import           IHaskellPrelude
 
 import qualified Data.Text as T
-import qualified Data.Text.Encoding as E
 
 import           IHaskell.Display
 import           IHaskell.Types
@@ -67,15 +66,7 @@ publishResult send replyHeader displayed updateNeeded poutput upager result = do
     sendOutput (ManyDisplay manyOuts) = mapM_ sendOutput manyOuts
     sendOutput (Display outs) = do
       hdr <- dupHeader replyHeader DisplayDataMessage
-      send $ PublishDisplayData hdr (map (convertSvgToHtml . prependCss) outs) Nothing
-
-    convertSvgToHtml (DisplayData MimeSvg s) = html $ makeSvgImg $ base64 $ E.encodeUtf8 s
-    convertSvgToHtml x = x
-
-    makeSvgImg :: Base64 -> String
-    makeSvgImg base64data = T.unpack $ "<img src=\"data:image/svg+xml;base64," <>
-                                       base64data <>
-                                       "\"/>"
+      send $ PublishDisplayData hdr (map prependCss outs) Nothing
 
     prependCss (DisplayData MimeHtml h) =
       DisplayData MimeHtml $ mconcat ["<style>", T.pack ihaskellCSS, "</style>", h]


### PR DESCRIPTION
On my setup it works with both browser and emacs front-ends.