### PR TITLE
labextension npm dependency bounds loosen

### DIFF
--- a/ihaskell_labextension/package.json
+++ b/ihaskell_labextension/package.json
@@ -30,10 +30,10 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@jupyterlab/application": "^0.17.1",
-    "@jupyterlab/apputils": "^0.17.2",
-    "@jupyterlab/docregistry": "^0.17.1",
-    "@jupyterlab/notebook": "^0.17.1",
+    "@jupyterlab/application": "0.17.1 - 2.0.0",
+    "@jupyterlab/apputils": "0.17.2 - 2.0.0",
+    "@jupyterlab/docregistry": "0.17.1 - 2.0.0",
+    "@jupyterlab/notebook": "0.17.1 - 2.0.0",
     "@jupyterlab/services": "^3.0.1",
     "@phosphor/disposable": "^1.1.2"
   },


### PR DESCRIPTION
Relax upper version bounds on the jupyterlab alpha dependencies
for ihaskell_labextension. It looks to me like these version bounds
were intended to allow the entire major alpha 0.\*.\* version range, but
the the prefix caret only includes minor versions if the major version
is 0.

Let's set the upper bound to 2.0.0, because according to SemVer, that
is the next version number which we would expect to have breaking
changes.

Resolves #1020