### PR TITLE
rm ihaskell-display/ihaskell-*/stack.yaml

### DIFF
--- a/ihaskell-display/ihaskell-aeson/stack.yaml
+++ b/ihaskell-display/ihaskell-aeson/stack.yaml
@@ -1,4 +1,0 @@
-flags: {}
-packages:
-- '.'
-resolver: lts-9.21

--- a/ihaskell-display/ihaskell-blaze/stack.yaml
+++ b/ihaskell-display/ihaskell-blaze/stack.yaml
@@ -1,4 +1,0 @@
-flags: {}
-packages:
-- '.'
-resolver: lts-9.21

--- a/ihaskell-display/ihaskell-charts/stack.yaml
+++ b/ihaskell-display/ihaskell-charts/stack.yaml
@@ -1,4 +1,0 @@
-flags: {}
-packages:
-- '.'
-resolver: lts-9.21

--- a/ihaskell-display/ihaskell-diagrams/stack.yaml
+++ b/ihaskell-display/ihaskell-diagrams/stack.yaml
@@ -1,4 +1,0 @@
-flags: {}
-packages:
-- '.'
-resolver: lts-9.21

--- a/ihaskell-display/ihaskell-gnuplot/stack.yaml
+++ b/ihaskell-display/ihaskell-gnuplot/stack.yaml
@@ -1,5 +1,0 @@
-flags: {}
-packages:
-- '.'
-resolver: lts-9.21
-extra-deps: []

--- a/ihaskell-display/ihaskell-graphviz/stack.yaml
+++ b/ihaskell-display/ihaskell-graphviz/stack.yaml
@@ -1,5 +1,0 @@
-flags: {}
-packages:
-- '.'
-resolver: lts-9.21
-extra-deps: []

--- a/ihaskell-display/ihaskell-hatex/stack.yaml
+++ b/ihaskell-display/ihaskell-hatex/stack.yaml
@@ -1,4 +1,0 @@
-flags: {}
-packages:
-- '.'
-resolver: lts-9.21

--- a/ihaskell-display/ihaskell-juicypixels/stack.yaml
+++ b/ihaskell-display/ihaskell-juicypixels/stack.yaml
@@ -1,4 +1,0 @@
-flags: {}
-packages:
-- '.'
-resolver: lts-9.21

--- a/ihaskell-display/ihaskell-magic/stack.yaml
+++ b/ihaskell-display/ihaskell-magic/stack.yaml
@@ -1,4 +1,0 @@
-flags: {}
-packages:
-- '.'
-resolver: lts-9.21

--- a/ihaskell-display/ihaskell-plot/stack.yaml
+++ b/ihaskell-display/ihaskell-plot/stack.yaml
@@ -1,4 +1,0 @@
-flags: {}
-packages:
-- '.'
-resolver: lts-9.21

--- a/ihaskell-display/ihaskell-rlangqq/stack.yaml
+++ b/ihaskell-display/ihaskell-rlangqq/stack.yaml
@@ -1,4 +1,0 @@
-flags: {}
-packages:
-- '.'
-resolver: lts-9.21

--- a/ihaskell-display/ihaskell-static-canvas/stack.yaml
+++ b/ihaskell-display/ihaskell-static-canvas/stack.yaml
@@ -1,4 +1,0 @@
-flags: {}
-packages:
-- '.'
-resolver: lts-9.21

--- a/ihaskell-display/ihaskell-widgets/stack.yaml
+++ b/ihaskell-display/ihaskell-widgets/stack.yaml
@@ -1,4 +1,0 @@
-flags: {}
-packages:
-- '.'
-resolver: lts-9.21


### PR DESCRIPTION
Andrew Gibiansky created all these package `stack.yaml`s with this commit:

> commit f9846b6bd9f162b763cc53662e0db357b2aec03a
> Author: Andrew Gibiansky <andrew.gibiansky@gmail.com>
> Date:   Tue Jun 7 17:26:47 2016 -0700
>
>     Separate stack.yaml for each package for simplicity

The resolvers for all these stack yamls originally agreed with the
root stack.yaml, but now they're way off, apparently out of neglect.
Let's just delete them.