### PR TITLE
ihaskell_labextension for JupyterLab 1.0.0

### DIFF
--- a/ihaskell_labextension/package.json
+++ b/ihaskell_labextension/package.json
@@ -34,7 +34,7 @@
     "@jupyterlab/apputils": "0.17.2 - 2.0.0",
     "@jupyterlab/docregistry": "0.17.1 - 2.0.0",
     "@jupyterlab/notebook": "0.17.1 - 2.0.0",
-    "@jupyterlab/services": "^3.0.1",
+    "@jupyterlab/services": ">=3.0.1",
     "@phosphor/disposable": "^1.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
If we remove the upper version bound for the `jupyterlab/services`
dependency, then `ihaskell_labextension` works fine with __JupyterLab 1.0.0__.

https://github.com/jupyterlab/jupyterlab/commit/e2fd4c8841a7393f9131fb6b6e8252864a8bd351