### PR TITLE
fix build failures parsing __attribute__ in headers

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -21,9 +21,9 @@ extra-deps:
 - Chart-cairo-1.9.1
 - diagrams-cairo-1.4.1
 - cairo-0.13.6.0
-- pango-0.13.6.0
-- glib-0.13.7.0
-- gtk2hs-buildtools-0.13.5.0
+- pango-0.13.6.1
+- glib-0.13.7.1
+- gtk2hs-buildtools-0.13.5.4
 - magic-1.1
 # - plot-0.2.3.9
 


### PR DESCRIPTION
Recent glib.h and pango versions cause parser error:
```
lib                > /usr/include/glib-2.0/glib/gspawn.h:76: (column 22) [FATAL]
glib                >   >>> Syntax error!
glib                >   The symbol `__attribute__' does not fit here.
glib                >
...
--  While building package glib-0.13.7.0 using:
      /tmp/stack-b0950acaedbd96af/glib-0.13.7.0/.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/setup/setup --builddir=.stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1 build --ghc-options " -fdiagnostics-color=always"
    Process exited with code: ExitFailure 1
Progress 6/18
```
This has been [fixed with latest versions](https://github.com/gtk2hs/gtk2hs/releases) of `pango`, `glib` and `gtk2hs-buildtools`. This updates stack.yaml to use updated versions.