### PR TITLE
Fix the lower bound on ipython-kernel

### DIFF
--- a/ihaskell.cabal
+++ b/ihaskell.cabal
@@ -147,7 +147,7 @@ executable ihaskell
                        strict               >=0.3,
                        unix                 >= 2.6,
                        directory            -any,
-                       ipython-kernel       >=0.7,
+                       ipython-kernel       >=0.10,
                        unordered-containers -any
 
 Test-Suite hspec


### PR DESCRIPTION
Fixing compilation error, which is due to this commit: https://github.com/gibiansky/IHaskell/commit/196ccac96d6164637d830c7afc9c6dcb13b9db4b A cabal revision on hackage could be useful as well.
```
ihaskell                         > Preprocessing library for ihaskell-0.10.0.0..
ihaskell                         > Building library for ihaskell-0.10.0.0..
ihaskell                         > [ 1 of 25] Compiling IHaskellPrelude
ihaskell                         > [ 2 of 25] Compiling IHaskell.Types
ihaskell                         > 
ihaskell                         > /tmp/stack29579/ihaskell-0.10.0.0/src/IHaskell/Types.hs:278:16: error:
ihaskell                         >     Not in scope: ‘mhMessageId’
ihaskell                         >     Perhaps you meant ‘messageId’ (imported from IHaskell.IPython.Kernel)
ihaskell                         >     |
ihaskell                         > 278 |   return hdr { mhMessageId = uuid, mhMsgType = messageType }
ihaskell                         >     |                ^^^^^^^^^^^
ihaskell                         > 
ihaskell                         > /tmp/stack29579/ihaskell-0.10.0.0/src/IHaskell/Types.hs:278:36: error:
ihaskell                         >     Not in scope: ‘mhMsgType’
ihaskell                         >     Perhaps you meant ‘msgType’ (imported from IHaskell.IPython.Kernel)
ihaskell                         >     |
ihaskell                         > 278 |   return hdr { mhMessageId = uuid, mhMsgType = messageType }
ihaskell                         >     |                                    ^^^^^^^^^
ihaskell                         > 
```