### PR TITLE
fix typo in channel name

### DIFF
--- a/ipython-kernel/src/IHaskell/IPython/EasyKernel.hs
+++ b/ipython-kernel/src/IHaskell/IPython/EasyKernel.hs
@@ -144,7 +144,7 @@ easyKernel profileFile config = do
     repHeader <- createReplyHeader (header req)
     when (debug config) . liftIO $ print req
     reply <- replyTo config execCount zmq req repHeader
-    liftIO $ writeChan (shellRequestChannel zmq) reply
+    liftIO $ writeChan (shellReplyChannel zmq) reply
 
 replyTo :: MonadIO m
         => KernelConfig m output result


### PR DESCRIPTION
There was a typo in `ipython-kernel` that caused infinite loop when starting custom kernel using `easyKernel`: reply was send to wrong channel.