### PR TITLE
IHaskell.ipynb replace dead img src

### DIFF
--- a/notebooks/IHaskell.ipynb
+++ b/notebooks/IHaskell.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![](https://camo.githubusercontent.com/f6540337202bb3b0c2545d90de0791c9196f9510/68747470733a2f2f7261772e6769746875622e636f6d2f67696269616e736b792f494861736b656c6c2f6d61737465722f68746d6c2f6c6f676f2d36347836342e706e67)\n",
+    "![](https://www.haskell.org/img/haskell-logo.svg)\n",
     "\n",
     "IHaskell Notebook\n",
     "===\n",


### PR DESCRIPTION
I don't know what image was there before, but it's gone now. Let's put in the
Haskell logo from haskell.org.