### PR TITLE
Add a MimeCustomJson type

### DIFF
--- a/src/IHaskell/Display.hs
+++ b/src/IHaskell/Display.hs
@@ -38,6 +38,7 @@ module IHaskell.Display (
     vegalite,
     vdom,
     custom,
+    customJson,
     many,
 
     -- ** Image and data encoding functions
@@ -121,6 +122,11 @@ vdom = DisplayData MimeVdom . T.pack
 -- payload.
 custom :: T.Text -> String -> DisplayData
 custom mimetype = DisplayData (MimeCustom mimetype) . T.pack
+
+-- | Generate a custom display. The first argument is the mimetype and the second argument is the
+-- payload (which is encoded as JSON).
+customJson :: T.Text -> String -> DisplayData
+customJson mimetype = DisplayData (MimeCustomJson mimetype) . T.pack
 
 -- | Generate a Markdown display.
 markdown :: String -> DisplayData


### PR DESCRIPTION
The MimeCustom type encodes the payload as a JSON string, whereas
MimeCustomJson encodes it as a JSON value. An alternative would
have been to just convert the MimeCustom type to encode as a Value
directy, but I wanted to see how this works.

This is for #1173 and suffers from the issue discussed at https://github.com/gibiansky/IHaskell/issues/1173#issuecomment-629931984

On the plus side, using it I was able to add a custom Mime handler for an updated version of the VegaLite mime type (but only v3 and not v4 as I think that either requires updating to jupyter lab v2 or adding some mythical support to jupyter lab 1.2 to add the v4 mimetype)