### PR TITLE
sendMessage mhMetadata

### DIFF
--- a/ipython-kernel/src/IHaskell/IPython/ZeroMQ.hs
+++ b/ipython-kernel/src/IHaskell/IPython/ZeroMQ.hs
@@ -344,6 +344,6 @@ sendMessage debug hmackey sock msg = do
     hdr = header msg
     parentHeaderStr = maybe "{}" encodeStrict $ mhParentHeader hdr
     idents = mhIdentifiers hdr
-    metadata = "{}"
+    metadata = let Metadata mdobject = mhMetadata hdr in encodeStrict mdobject
     content = encodeStrict msg
     headStr = encodeStrict hdr


### PR DESCRIPTION
Send the header metadata with a message instead of ignoring the header
metadata and sending "{}".

The header metadata is handled correctly on receipt of a message. Why
was it ignored on sending? Probably no-one ever needed it.

Resolves #1177