### PR TITLE
Add mimetype to Kernel Info Reply message

### DIFF
--- a/ipython-kernel/src/IHaskell/IPython/Types.hs
+++ b/ipython-kernel/src/IHaskell/IPython/Types.hs
@@ -281,6 +281,10 @@ instance FromJSON MessageType where
       _                     -> fail ("Unknown message type: " ++ show s)
   parseJSON _ = fail "Must be a string."
 
+-- | Kernel language info, see
+--
+-- * https://jupyter-client.readthedocs.io/en/stable/messaging.html#kernel-info
+-- * https://jupyter-client.readthedocs.io/en/stable/wrapperkernels.html#MyKernel.language_info
 data LanguageInfo =
        LanguageInfo
          { languageName :: String        -- ^ The language name, e.g. "haskell"
@@ -288,6 +292,7 @@ data LanguageInfo =
          , languageFileExtension :: String        -- ^ .hs
          , languageCodeMirrorMode :: String        -- ^ 'ihaskell'. can be 'null'
          , languagePygmentsLexer :: String
+         , languageMimeType :: String       -- "text/x-haskell"
          }
   deriving (Show, Eq)
 
@@ -298,6 +303,7 @@ instance ToJSON LanguageInfo where
                   , "file_extension" .= languageFileExtension info
                   , "codemirror_mode" .= languageCodeMirrorMode info
                   , "pygments_lexer" .= languagePygmentsLexer info
+                  , "mimetype" .= languageMimeType info
                   ]
 
 data CodeReview = CodeComplete
@@ -317,6 +323,9 @@ instance ToJSON Transient where
                     ]
 
 -- | A message used to communicate with the IPython frontend.
+--
+-- See
+-- https://jupyter-client.readthedocs.io/en/stable/messaging.html
 data Message =
              -- | A request from a frontend for information about the kernel.
               KernelInfoRequest { header :: MessageHeader }

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -248,6 +248,7 @@ replyTo interface KernelInfoRequest{} replyHeader state = do
                 , languageFileExtension = ".hs"
                 , languageCodeMirrorMode = "ihaskell"
                 , languagePygmentsLexer = "Haskell"
+                , languageMimeType = "text/x-haskell" -- https://jupyter-client.readthedocs.io/en/stable/wrapperkernels.html#MyKernel.language_info
                 }
               , status = Ok
               })

--- a/test/acceptance.nbconvert.in.ipynb
+++ b/test/acceptance.nbconvert.in.ipynb
@@ -1251,6 +1251,7 @@
   "language_info": {
    "codemirror_mode": "ihaskell",
    "file_extension": ".hs",
+   "mimetype": "text/x-haskell",
    "name": "haskell",
    "pygments_lexer": "Haskell",
    "version": "8.6.5"


### PR DESCRIPTION
The `"mimetype"` is a required field, and is needed by __jupyterlab-lsp__ and probably other things.

See https://github.com/krassowski/jupyterlab-lsp/issues/313

Resolves #1181