### PR TITLE
Add dynamic flag to load extra shared library

### DIFF
--- a/ihaskell.cabal
+++ b/ihaskell.cabal
@@ -123,7 +123,7 @@ executable ihaskell
   hs-source-dirs: main
   other-modules:
                    Paths_ihaskell
-  ghc-options: -threaded -rtsopts -Wall
+  ghc-options: -threaded -rtsopts -Wall -dynamic
 
   if os(darwin)
     ghc-options: -optP-Wno-nonportable-include-path


### PR DESCRIPTION
This pr adds -dynamic flag for ihaskell executable file.
External libraries such as libstdc++ cannot be loaded dynamically because there is no dynamic flag.

I verified it here.
https://github.com/hasktorch/hasktorch-jupyter/blob/master/Dockerfile#L55-L56

