### PR TITLE
Bump mimetypes of vega

### DIFF
--- a/ipython-kernel/src/IHaskell/IPython/Types.hs
+++ b/ipython-kernel/src/IHaskell/IPython/Types.hs
@@ -814,8 +814,8 @@ instance Show MimeType where
   show MimeMarkdown = "text/markdown"
   show MimeJavascript = "application/javascript"
   show MimeJson = "application/json"
-  show MimeVega = "application/vnd.vega.v2+json"
-  show MimeVegalite = "application/vnd.vegalite.v2+json"
+  show MimeVega = "application/vnd.vega.v5+json"
+  show MimeVegalite = "application/vnd.vegalite.v4+json"
   show MimeVdom = "application/vdom.v1+json"
   show (MimeCustom custom) = Text.unpack custom
 
@@ -831,8 +831,8 @@ instance Read MimeType where
   readsPrec _ "text/markdown" = [(MimeMarkdown, "")]
   readsPrec _ "application/javascript" = [(MimeJavascript, "")]
   readsPrec _ "application/json" = [(MimeJson, "")]
-  readsPrec _ "application/vnd.vega.v2+json" = [(MimeVega, "")]
-  readsPrec _ "application/vnd.vegalite.v1+json" = [(MimeVegalite, "")]
+  readsPrec _ "application/vnd.vega.v5+json" = [(MimeVega, "")]
+  readsPrec _ "application/vnd.vegalite.v4+json" = [(MimeVegalite, "")]
   readsPrec _ "application/vdom.v1+json" = [(MimeVdom, "")]
   readsPrec _ t = [(MimeCustom (Text.pack t), "")]
 


### PR DESCRIPTION
The latest jupyterlab does not support both vega-v2 and vegalite-v2.
https://github.com/jupyterlab/jupyterlab/blob/f0153e0258b32674c9aec106383ddf7b618cebab/packages/vega5-extension/src/index.ts#L33-L49

So it can not display the images using vega.

This pr dumps vega's version of mimetype to show vega-images.