### PR TITLE
add codemirror command line flag

### DIFF
--- a/src/IHaskell/Flags.hs
+++ b/src/IHaskell/Flags.hs
@@ -31,6 +31,7 @@ data Argument = ConfFile String     -- ^ A file with commands to load at startup
               | KernelDebug         -- ^ Spew debugging output from the kernel.
               | Help                -- ^ Display help text.
               | Version             -- ^ Display version text.
+              | CodeMirror String   -- ^ change codemirror mode (default=ihaskell)
               | ConvertFrom String
               | ConvertTo String
               | ConvertFromFormat NotebookFormat
@@ -113,6 +114,10 @@ kernelDebugFlag = flagNone ["debug"] addDebug "Print debugging output from the k
   where
     addDebug (Args md prev) = Args md (KernelDebug : prev)
 
+kernelCodeMirrorFlag :: Flag Args
+kernelCodeMirrorFlag = flagReq ["codemirror"] (store CodeMirror) "<codemirror>"
+        "Specify codemirror mode that is used for syntax highlighting (default: ihaskell)."
+
 kernelStackFlag :: Flag Args
 kernelStackFlag = flagNone ["stack"] addStack
                     "Inherit environment from `stack` when it is installed"
@@ -143,7 +148,7 @@ installKernelSpec =
 
 kernel :: Mode Args
 kernel = mode "kernel" (Args (Kernel Nothing) []) "Invoke the IHaskell kernel." kernelArg
-           [ghcLibFlag, kernelDebugFlag, confFlag, kernelStackFlag]
+           [ghcLibFlag, kernelDebugFlag, confFlag, kernelStackFlag, kernelCodeMirrorFlag]
   where
     kernelArg = flagArg update "<json-kernel-file>"
     update filename (Args _ flags) = Right $ Args (Kernel $ Just filename) flags

--- a/src/IHaskell/IPython.hs
+++ b/src/IHaskell/IPython.hs
@@ -39,6 +39,7 @@ data KernelSpecOptions =
          { kernelSpecGhcLibdir :: String           -- ^ GHC libdir.
          , kernelSpecRTSOptions :: [String]        -- ^ Runtime options to use.
          , kernelSpecDebug :: Bool                 -- ^ Spew debugging output?
+         , kernelSpecCodeMirror :: String          -- ^ CodeMirror mode
          , kernelSpecConfFile :: IO (Maybe String) -- ^ Filename of profile JSON file.
          , kernelSpecInstallPrefix :: Maybe String
          , kernelSpecUseStack :: Bool              -- ^ Whether to use @stack@ environments.
@@ -50,6 +51,7 @@ defaultKernelSpecOptions = KernelSpecOptions
   , kernelSpecRTSOptions = ["-M3g", "-N2"]  -- Memory cap 3 GiB,
                                             -- multithreading on two processors.
   , kernelSpecDebug = False
+  , kernelSpecCodeMirror = "ihaskell"
   , kernelSpecConfFile = defaultConfFile
   , kernelSpecInstallPrefix = Nothing
   , kernelSpecUseStack = False


### PR DESCRIPTION
How about this? I have tested it with jupyterWith and you can do:

```
  iHaskell = jupyter.kernels.iHaskellWith {
    name = "haskell";
    packages = p: with p; [ p.vinyl p.lens p.singletons p.aeson ];
    extraIHaskellFlags = "--codemirror Haskell";
  };
  jupyterEnvironment =
    jupyter.jupyterlabWith {
      kernels = [ iHaskell ];
    };
```

This gives syntax highlighting without any extension which simplifies the whole setup quite a lot!

