### PR TITLE
IHaskell.Eval.Evaluate: don't output HTML on shell command failure

### DIFF
--- a/src/IHaskell/Eval/Evaluate.hs
+++ b/src/IHaskell/Eval/Evaluate.hs
@@ -709,11 +709,7 @@ evalCommand publish (Directive ShellCmd cmd) state = wrapExecution state $
                   ExitSuccess -> return $ Display [plain out]
                   ExitFailure code -> do
                     let errMsg = "Process exited with error code " ++ show code
-                        htmlErr = printf "<span class='err-msg'>%s</span>" errMsg
-                    return $ Display
-                               [ plain $ out ++ "\n" ++ errMsg
-                               , html $ printf "<span class='mono'>%s</span>" out ++ htmlErr
-                               ]
+                    return $ Display [plain $ out ++ "\n" ++ errMsg]
 
       loop
 -- This is taken largely from GHCi's info section in InteractiveUI.


### PR DESCRIPTION
Closes https://github.com/gibiansky/IHaskell/issues/1196.