### PR TITLE
Support for GHC 8.10

### DIFF
--- a/ihaskell-display/ihaskell-widgets/src/IHaskell/Display/Widgets/Singletons.hs
+++ b/ihaskell-display/ihaskell-widgets/src/IHaskell/Display/Widgets/Singletons.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE PolyKinds #-}
@@ -11,6 +12,9 @@
 {-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE TypeApplications #-}
+#if __GLASGOW_HASKELL__ >= 810
+{-# LANGUAGE StandaloneKindSignatures #-}
+#endif
 
 module IHaskell.Display.Widgets.Singletons where
 

--- a/stack-8.8.yaml
+++ b/stack-8.8.yaml
@@ -1,5 +1,4 @@
-resolver: lts-17.4
-allow-newer: true
+resolver: lts-16.23
 
 flags: {}
 packages:
@@ -19,14 +18,8 @@ packages:
     - ./ihaskell-display/ihaskell-widgets
 
 extra-deps:
-- active-0.2.0.14
 - Chart-cairo-1.9.3
-- diagrams-1.4
 - diagrams-cairo-1.4.1.1
-- diagrams-contrib-1.4.4
-- diagrams-core-1.4.2
-- diagrams-lib-1.4.3
-- diagrams-svg-1.4.3
 - cairo-0.13.8.1
 - pango-0.13.8.1
 - glib-0.13.8.1
@@ -34,12 +27,7 @@ extra-deps:
 - magic-1.1
 - plot-0.2.3.11
 # - static-canvas-0.2.0.3
-- statestack-0.3
 - vinyl-0.13.0
-- dual-tree-0.2.2.1
-- monoid-extras-0.5.1
-- svg-builder-0.1.1
-- force-layout-0.4.0.6
 
 ghc-options:
   # Eventually we want "$locals": -Wall -Wpartial-fields -Werror


### PR DESCRIPTION
The main reason why this is important is that GHC 8.10.3 ships with a [fix](https://gitlab.haskell.org/ghc/ghc/-/issues/18446) that allows compilation in macOS Big Sur, which otherwise fails.