### PR TITLE
Enable CodeMirror syntax highlighting in JupyterLab

### DIFF
--- a/src/IHaskell/IPython.hs
+++ b/src/IHaskell/IPython.hs
@@ -51,7 +51,7 @@ defaultKernelSpecOptions = KernelSpecOptions
   , kernelSpecRTSOptions = ["-M3g", "-N2"]  -- Memory cap 3 GiB,
                                             -- multithreading on two processors.
   , kernelSpecDebug = False
-  , kernelSpecCodeMirror = "ihaskell"
+  , kernelSpecCodeMirror = "Haskell"
   , kernelSpecConfFile = defaultConfFile
   , kernelSpecInstallPrefix = Nothing
   , kernelSpecUseStack = False
@@ -138,6 +138,7 @@ installKernelspec repl opts = void $ do
            Nothing   -> []
            Just file -> ["--conf", file])
         ++ ["--ghclib", kernelSpecGhcLibdir opts]
+        ++ ["--codemirror", kernelSpecCodeMirror opts]
         ++ (case kernelSpecRTSOptions opts of
              [] -> []
              _ -> "+RTS" : kernelSpecRTSOptions opts ++ ["-RTS"])

--- a/test/acceptance.nbconvert.in.ipynb
+++ b/test/acceptance.nbconvert.in.ipynb
@@ -1235,7 +1235,7 @@
    "name": "haskell"
   },
   "language_info": {
-   "codemirror_mode": "ihaskell",
+   "codemirror_mode": "Haskell",
    "file_extension": ".hs",
    "mimetype": "text/x-haskell",
    "name": "haskell",


### PR DESCRIPTION
Continuation of https://github.com/gibiansky/IHaskell/pull/1191

Resolves #1199

Also will satisfy older issues #1202 #1120 