### PR TITLE
ihaskell-widgets: support singletons-3.0

### DIFF
--- a/ihaskell-display/ihaskell-widgets/ihaskell-widgets.cabal
+++ b/ihaskell-display/ihaskell-widgets/ihaskell-widgets.cabal
@@ -112,6 +112,9 @@ library
 					 -- so let cabal choose the right one.
                      , singletons -any
 
+  if impl (ghc >= 9.0)
+    build-depends:     singletons-base -any
+
   -- Directories containing source files.
   hs-source-dirs:      src
 

--- a/ihaskell-display/ihaskell-widgets/src/IHaskell/Display/Widgets/Singletons.hs
+++ b/ihaskell-display/ihaskell-widgets/src/IHaskell/Display/Widgets/Singletons.hs
@@ -18,11 +18,13 @@
 
 module IHaskell.Display.Widgets.Singletons where
 
+#if MIN_VERSION_singletons(3,0,0)
+import           Data.Singletons.Base.TH
+#elif MIN_VERSION_singletons(2,4,0)
 import           Data.Singletons.TH
-
-#if MIN_VERSION_singletons(2,4,0)
 #else
 import           Data.Singletons.Prelude.Ord
+import           Data.Singletons.TH
 #endif
 
 -- Widget properties

--- a/ihaskell-display/ihaskell-widgets/src/IHaskell/Display/Widgets/Types.hs
+++ b/ihaskell-display/ihaskell-widgets/src/IHaskell/Display/Widgets/Types.hs
@@ -85,13 +85,19 @@ import           Data.Vinyl.Functor (Compose(..), Const(..))
 import           Data.Vinyl.Lens (rget, rput, type (∈))
 import           Data.Vinyl.TypeLevel (RecAll)
 
-#if MIN_VERSION_singletons(2,4,0)
+#if MIN_VERSION_singletons(3,0,0)
+import           Data.List.Singletons
+#elif MIN_VERSION_singletons(2,4,0)
 import           Data.Singletons.Prelude.List
 #else
 import           Data.Singletons.Prelude ((:++))
 #endif
 
+#if MIN_VERSION_singletons(3,0,0)
+import           Data.Singletons.Base.TH
+#else
 import           Data.Singletons.TH
+#endif
 
 import           GHC.IO.Exception
 


### PR DESCRIPTION
Tested by running (with `nixpkgs-21.05`)

```
$ nix-shell -p haskell.compiler.ghc901 cabal-install zlib.dev zeromq pkgconfig
$ cd ihaskell-display/ihaskell-widgets
$ cabal build --keep-going
```