### PR TITLE
replaceOutput runs without flickering the GUI

### DIFF
--- a/ihaskell-display/ihaskell-widgets/src/IHaskell/Display/Widgets.hs
+++ b/ihaskell-display/ihaskell-widgets/src/IHaskell/Display/Widgets.hs
@@ -77,4 +77,6 @@ import           IHaskell.Display.Widgets.Common as X
 import           IHaskell.Display.Widgets.Types as X (setField, getField, properties, triggerDisplay,
                                                       triggerChange, triggerClick, triggerSelection,
                                                       triggerSubmit, ChildWidget(..), StyleWidget(..),
-                                                      WidgetFieldPair(..), Date(..), unlink, JSONByteString(..))
+                                                      WidgetFieldPair(..), Date(..), unlink,
+                                                      JSONByteString(..), OutputMsg(..))
+

--- a/ihaskell-display/ihaskell-widgets/src/IHaskell/Display/Widgets/Output.hs
+++ b/ihaskell-display/ihaskell-widgets/src/IHaskell/Display/Widgets/Output.hs
@@ -107,8 +107,8 @@ clearOutput_ widget = widgetClearOutput True >> clearOutput' widget
 -- | Replace the currently displayed output for output widget
 replaceOutput :: IHaskellDisplay a => OutputWidget -> a -> IO ()
 replaceOutput widget d = do
-    clearOutput_ widget
-    appendDisplay widget d
+    disp <- display d
+    setField widget Outputs [OutputData disp]
 
 instance IHaskellWidget OutputWidget where
   getCommUUID = uuid


### PR DESCRIPTION
Also export `OutputMsg` constructors so that users can call
`setField` on an `OutputWidget` to write their own `replaceOutput`
functions.