### PR TITLE
Fix PermissionError

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,8 +83,9 @@ COPY --from=builder --chown=${NB_UID} /data/hlint.yaml ${HLINT_DATA_DIR}/
 ENV hlint_datadir ${HLINT_DATA_DIR}
 
 # Set current user + directory
-USER ${NB_UID}
 WORKDIR /home/${NB_USER}/src
+RUN chown -R ${NB_UID} /home/${NB_USER}/src
+USER ${NB_UID}
 
 # Set up global project
 COPY --from=builder --chown=${NB_UID} /build/resolver.txt /tmp/


### PR DESCRIPTION
:sparkles: _**This is an old work account. Please reference @brandonchinn178 for all future communication**_ :sparkles:
<!-- updated by mention_personal_account_in_comments.py -->

---

When running `docker run ...` without mounting, you get a PermissionError when you try to create any file because `~/src/` is owned by `root`, not `jovyan`