### PR TITLE
Remove imports

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -13,3 +13,8 @@ packages: .
           ./ihaskell-display/ihaskell-plot
           ./ihaskell-display/ihaskell-static-canvas
           ./ihaskell-display/ihaskell-widgets
+
+source-repository-package
+  type: git
+  location: https://github.com/jeffreyrosenbluth/static-canvas.git
+  tag: 1aad0f192828ded72dced14e42ac4e6baa6dab6f

--- a/flake.nix
+++ b/flake.nix
@@ -16,41 +16,54 @@
   outputs = { self, hls, nixpkgs, flake-utils, ... }:
     flake-utils.lib.eachSystem ["x86_64-linux"] (system: let
 
-      compilerVersion = "8107";
-
       pkgs = import nixpkgs {
         inherit system;
       };
 
-      ihaskellEnv = import ./release.nix {
-        compiler = "ghc${compilerVersion}";
-        nixpkgs = pkgs;
-      };
+      ihaskellEnv = compilerVersion:
+        import ./release.nix {
+          compiler = "ghc${compilerVersion}";
+          nixpkgs = pkgs;
+        };
 
-      hsPkgs = pkgs.haskell.packages."ghc${compilerVersion}";
+      ghc884  = pkgs.haskell.packages.ghc884;
+      ghc8107  = pkgs.haskell.packages.ghc8107;
 
-      myModifier = drv:
-        pkgs.haskell.lib.addBuildTools drv (with hsPkgs; [
-          cabal-install
-          self.inputs.hls.packages."${system}"."haskell-language-server-${compilerVersion}"
-        ]);
-    in {
+      mkDevShell = hsPkgs:
+        let
+          myIHaskell = (mkPackage hsPkgs);
+          compilerVersion = pkgs.lib.replaceStrings [ "." ] [ "" ] hsPkgs.ghc.version;
 
-      packages = {
-        ihaskell = hsPkgs.developPackage {
+          myModifier = drv:
+            pkgs.haskell.lib.addBuildTools drv (with hsPkgs; [
+              cabal-install
+              self.inputs.hls.packages.${system}."haskell-language-server-${compilerVersion}"
+            ]);
+        in (myModifier myIHaskell).envFunc {withHoogle=true;};
+
+
+      mkPackage = hsPkgs:
+        let
+          compilerVersion = pkgs.lib.replaceStrings [ "." ] [ "" ] hsPkgs.ghc.version;
+        in
+        hsPkgs.developPackage {
           root =  pkgs.lib.cleanSource ./.;
           name = "ihaskell";
           returnShellEnv = false;
           modifier = pkgs.haskell.lib.dontCheck;
-          overrides = ihaskellEnv.ihaskellOverlay;
+          overrides = (ihaskellEnv compilerVersion).ihaskellOverlay ;
           withHoogle = true;
         };
 
-        ihaskellEnv = ihaskellEnv;
+    in {
+
+      packages = {
+        ihaskell = mkDevShell ghc8107;
+        ihaskell8107 = mkDevShell ghc8107;
+        ihaskell884 = mkDevShell ghc884;
+        ihaskellEnv = ihaskellEnv ghc8107;
       };
 
       defaultPackage = self.packages.${system}.ihaskell;
-
-      devShell = (myModifier self.packages.${system}.ihaskell).envFunc {withHoogle=true;};
     });
 }

--- a/ipython-kernel/src/IHaskell/IPython/Message/Parser.hs
+++ b/ipython-kernel/src/IHaskell/IPython/Message/Parser.hs
@@ -8,7 +8,6 @@
 -- the low-level 0MQ interface.
 module IHaskell.IPython.Message.Parser (parseMessage) where
 
-import           Control.Applicative ((<$>), (<*>))
 import           Data.Aeson ((.:), (.:?), (.!=), decode, FromJSON, Result(..), Object, Value(..))
 import           Data.Aeson.Types (Parser, parse, parseEither)
 import           Data.ByteString hiding (unpack)

--- a/ipython-kernel/src/IHaskell/IPython/Message/UUID.hs
+++ b/ipython-kernel/src/IHaskell/IPython/Message/UUID.hs
@@ -3,7 +3,6 @@
 -- Generate, parse, and pretty print UUIDs for use with IPython.
 module IHaskell.IPython.Message.UUID (UUID, random, randoms, uuidToString) where
 
-import           Control.Applicative ((<$>))
 import           Control.Monad (mzero, replicateM)
 import           Data.Aeson
 import           Data.Text (pack)

--- a/ipython-kernel/src/IHaskell/IPython/Types.hs
+++ b/ipython-kernel/src/IHaskell/IPython/Types.hs
@@ -38,7 +38,6 @@ module IHaskell.IPython.Types (
     displayDataToJson,
     ) where
 
-import           Control.Applicative ((<$>), (<*>))
 import           Data.Aeson
 import           Data.Aeson.Types (typeMismatch)
 import           Data.ByteString (ByteString)

--- a/ipython-kernel/src/IHaskell/IPython/ZeroMQ.hs
+++ b/ipython-kernel/src/IHaskell/IPython/ZeroMQ.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, DoAndIfThenElse, FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings, DoAndIfThenElse, FlexibleContexts, CPP #-}
 
 -- | Description : Low-level ZeroMQ communication wrapper.
 --

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -15,7 +15,7 @@ import           Control.Arrow (second)
 import           Data.Aeson hiding (Success)
 import           System.Process (readProcess, readProcessWithExitCode)
 import           System.Exit (exitSuccess, ExitCode(ExitSuccess))
-import           Control.Exception (try, SomeException)
+import           Control.Exception (try)
 import           System.Environment (getArgs)
 import           System.Environment (setEnv)
 import           System.Posix.Signals

--- a/src/IHaskell/Convert.hs
+++ b/src/IHaskell/Convert.hs
@@ -5,14 +5,12 @@ module IHaskell.Convert (convert) where
 
 import           IHaskellPrelude
 
-import           Control.Monad (unless, when)
 import           Data.Functor.Identity (Identity(Identity))
 import           IHaskell.Convert.Args (ConvertSpec(..), fromJustConvertSpec, toConvertSpec)
 import           IHaskell.Convert.IpynbToLhs (ipynbToLhs)
 import           IHaskell.Convert.LhsToIpynb (lhsToIpynb)
 import           IHaskell.Flags (Argument)
 import           System.Directory (doesFileExist)
-import           Text.Printf (printf)
 
 -- | used by @IHaskell convert@
 convert :: [Argument] -> IO ()

--- a/src/IHaskell/Convert/Args.hs
+++ b/src/IHaskell/Convert/Args.hs
@@ -6,14 +6,10 @@ module IHaskell.Convert.Args (ConvertSpec(..), fromJustConvertSpec, toConvertSpe
 import           IHaskellPrelude
 import qualified Data.Text.Lazy as LT
 
-import           Control.Applicative ((<$>))
 import           Data.Functor.Identity (Identity(Identity))
 import           Data.Char (toLower)
-import           Data.List (partition)
-import           Data.Maybe (fromMaybe)
 import           IHaskell.Flags (Argument(..), LhsStyle, lhsStyleBird, NotebookFormat(..))
 import           System.FilePath ((<.>), dropExtension, takeExtension)
-import           Text.Printf (printf)
 
 -- | ConvertSpec is the accumulator for command line arguments
 data ConvertSpec f =

--- a/src/IHaskell/Eval/Completion.hs
+++ b/src/IHaskell/Eval/Completion.hs
@@ -14,9 +14,8 @@ module IHaskell.Eval.Completion (complete, completionTarget, completionType, Com
 
 import           IHaskellPrelude
 
-import           Control.Applicative ((<$>))
 import           Data.Char
-import           Data.List (nub, init, last, elemIndex, concatMap)
+import           Data.List (init, last, elemIndex)
 import qualified Data.List.Split as Split
 import qualified Data.List.Split.Internals as Split
 import           System.Environment (getEnv)

--- a/src/IHaskell/Eval/Evaluate.hs
+++ b/src/IHaskell/Eval/Evaluate.hs
@@ -23,7 +23,6 @@ import           IHaskellPrelude
 import           Control.Concurrent (forkIO, threadDelay)
 import           Data.Foldable (foldMap)
 import           Prelude (head, tail, last, init)
-import           Data.List (nubBy)
 import qualified Data.Set as Set
 import           Data.Char as Char
 import           Data.Dynamic
@@ -34,7 +33,6 @@ import           System.IO (hGetChar, hSetEncoding, utf8)
 import           System.Random (getStdGen, randomRs)
 import           System.Process
 import           System.Exit
-import           Data.Maybe (mapMaybe)
 import           System.Environment (getEnv)
 
 #if MIN_VERSION_ghc(9,2,0)
@@ -68,7 +66,6 @@ import           Bag
 import           DynFlags
 import           HscTypes
 import           InteractiveEval
-import           Exception (gtry)
 import           Exception hiding (evaluate)
 import           GhcMonad (liftIO)
 import           Outputable hiding ((<>))

--- a/src/IHaskell/Eval/Widgets.hs
+++ b/src/IHaskell/Eval/Widgets.hs
@@ -16,7 +16,6 @@ import           IHaskellPrelude
 
 import           Control.Concurrent.STM (atomically)
 import           Control.Concurrent.STM.TChan
-import           Control.Monad (foldM)
 import           Data.Aeson
 import           Data.ByteString.Base64 as B64 (decodeLenient)
 import qualified Data.Map as Map


### PR DESCRIPTION
I was trying to hack on ihaskell but the build logs were littered with unused imports so I cleaned up a bit.

I fixed the issue with static-canvas. I can drop that commit if you prefer but considering there has been no release since 2019, I think this is an ok fix.