### PR TITLE
improve flake by distinguishing different goals (development vs final executable vs with a jupyter environment)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -87,11 +87,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1633827357,
-        "narHash": "sha256-TjTkSYMjce1ejPVvidnFWluxij6LGZV5TSmx2IQPYX4=",
+        "lastModified": 1637213318,
+        "narHash": "sha256-ZgxPwV7t4DyGYP7aXoetq+JHtd73XlOV2fYSflQmOXw=",
         "owner": "haskell",
         "repo": "haskell-language-server",
-        "rev": "195fa4c0fff2fcc0c0001b28216b36a890629cd2",
+        "rev": "311107eabbf0537e0c192b2c377d282505b4eff1",
         "type": "github"
       },
       "original": {

--- a/src/IHaskell/Eval/Hoogle.hs
+++ b/src/IHaskell/Eval/Hoogle.hs
@@ -14,7 +14,6 @@ module IHaskell.Eval.Hoogle (
 
 import qualified Data.ByteString.Char8   as CBS
 import qualified Data.ByteString.Lazy    as LBS
-import           Data.Either             (either)
 import           IHaskellPrelude
 
 import           Data.Aeson

--- a/src/IHaskell/Eval/Parser.hs
+++ b/src/IHaskell/Eval/Parser.hs
@@ -20,7 +20,6 @@ import           IHaskellPrelude
 import           Data.Char (toLower)
 import           Data.List (maximumBy, inits)
 import           Prelude (head, tail)
-import           Control.Monad (msum)
 
 #if MIN_VERSION_ghc(8,4,0)
 import           GHC hiding (Located, Parsed)

--- a/src/IHaskell/Eval/Util.hs
+++ b/src/IHaskell/Eval/Util.hs
@@ -85,10 +85,6 @@ import           FastString
 #endif
 import           GHC
 
-import           Control.Monad (void)
-import           Data.Function (on)
-import           Data.List (nubBy)
-
 import           StringUtils (replace)
 
 #if MIN_VERSION_ghc(9,0,0)


### PR DESCRIPTION
When working with the flake I realised a few issues:
- I need some special tools just in dev
- some commands won't work without jupyter so let's bring it in

I took inspiration for the naming from 
https://github.com/haskell/haskell-language-server/blob/b05e14d7fbd0d600ec8e687b0ea29ad38a39341c/flake.nix#L237

I am still unsure about haskell-env vs jupyter-env or anything else. Better name it right straightaway since changing this afterwards would be a pain for 3rd party projects like jupyterWith.