### PR TITLE
feat(nix): add darwin support in flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
   };
 
   outputs = { self, hls, nixpkgs, flake-utils, ... }:
-    flake-utils.lib.eachSystem ["x86_64-linux"] (system: let
+    flake-utils.lib.eachSystem ["x86_64-linux" "x86_64-darwin"] (system: let
 
       pkgs = import nixpkgs {
         inherit system;


### PR DESCRIPTION
not enabling it in ihaskell make nix flake check fail for jupyterWith.

Not sure if that will work though.