### PR TITLE
Add jupyter to flake.nix dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,8 @@
       ghc8107  = pkgs.haskell.packages.ghc8107;
       ghc921  = pkgs.haskell.packages.ghc921;
 
+      pythonDevEnv = pkgs.python3.withPackages (p: [p.jupyterlab]);
+
       mkDevShell = hsPkgs:
         let
           myIHaskell = (mkPackage hsPkgs);
@@ -44,6 +46,7 @@
           myModifier = drv:
             pkgs.haskell.lib.addBuildTools drv (with hsPkgs; [
               cabal-install
+              pythonDevEnv
               self.inputs.hls.packages.${system}."haskell-language-server-${compilerVersion}"
             ]);
         in (myModifier myIHaskell).envFunc {withHoogle=true;};


### PR DESCRIPTION
## Summary

Part of fixing https://github.com/gibiansky/IHaskell/issues/1316
Adds `ipython`, `jupyter` and `jupyter-lab` to the environment of the dev shell. This way, there's definitely a jupyter notebook to run the IHaskell kernel with.

My laptop doesn't have this globally installed, so I think this is something the dev env might want to provide. Especially because it is not possible to run `ihaskell install` without it.

When people do have it installed globally, I don't reckon this will conflict too much. Though I'm not sure what happens if the version in the `flake.nix` is newer than the globally installed one. If it makes backwards incompatible changes to the files in a user's data directory that would be unfortunate. I'm not sure if Jupyter does that :thinking: 

It's an open question, feel free to reject this PR if it is considered inappropriate to provide those dependencies in here :+1: 