### PR TITLE
Return error when evaluation failed

### DIFF
--- a/main/Main.hs
+++ b/main/Main.hs
@@ -309,7 +309,10 @@ replyTo _ interface req@ExecuteRequest { getCode = code } replyHeader state = do
   -- Run code and publish to the frontend as we go.
   let widgetMessageHandler = widgetHandler send replyHeader
       publish = publishResult send replyHeader displayed updateNeeded pOut (usePager state)
-  updatedState <- evaluate state (T.unpack code) publish widgetMessageHandler
+  (updatedState, errorOccurred) <- evaluate state (T.unpack code) publish widgetMessageHandler
+  let executeReplyStatus = case errorOccurred of
+        Success -> Ok
+        Failure -> Err
 
   -- Take pager output if we're using the pager.
   pager <- if usePager state
@@ -320,7 +323,7 @@ replyTo _ interface req@ExecuteRequest { getCode = code } replyHeader state = do
                      { header = replyHeader
                      , pagerOutput = pager
                      , executionCounter = execCount
-                     , status = Ok
+                     , status = executeReplyStatus
                      })
 
 -- Check for a trailing empty line. If it doesn't exist, we assume the code is incomplete,


### PR DESCRIPTION
Fixes https://github.com/gibiansky/IHaskell/issues/1315

This causes the kernel to reply error when there is a parse error or evaluation error.

Tested on the notebook in the mentioned issue as follows:

```bash
$ jupyter nbconvert foo-haskell.ipynb --to notebook --execute
[NbConvertApp] Converting notebook foo-haskell.ipynb to notebook
Press Ctrl-C again to quit kernel.
Traceback (most recent call last):
  File "/nix/store/m04rbassmdvpid1hrscr890s7hvgikw5-python3.9-nbconvert-6.1.0/bin/.jupyter-nbconvert-wrapped", line 9, in <module>
    sys.exit(main())
  File "/nix/store/nf8h3gafpdgk98d823841x054v6zmdn2-python3-3.9.6-env/lib/python3.9/site-packages/jupyter_core/application.py", line 254, in launch_instance
    return super(JupyterApp, cls).launch_instance(argv=argv, **kwargs)
  File "/nix/store/nf8h3gafpdgk98d823841x054v6zmdn2-python3-3.9.6-env/lib/python3.9/site-packages/traitlets/config/application.py", line 846, in launch_instance
    app.start()
  File "/nix/store/nf8h3gafpdgk98d823841x054v6zmdn2-python3-3.9.6-env/lib/python3.9/site-packages/nbconvert/nbconvertapp.py", line 346, in start
    self.convert_notebooks()
  File "/nix/store/nf8h3gafpdgk98d823841x054v6zmdn2-python3-3.9.6-env/lib/python3.9/site-packages/nbconvert/nbconvertapp.py", line 518, in convert_notebooks
    self.convert_single_notebook(notebook_filename)
  File "/nix/store/nf8h3gafpdgk98d823841x054v6zmdn2-python3-3.9.6-env/lib/python3.9/site-packages/nbconvert/nbconvertapp.py", line 483, in convert_single_notebook
    output, resources = self.export_single_notebook(notebook_filename, resources, input_buffer=input_buffer)
  File "/nix/store/nf8h3gafpdgk98d823841x054v6zmdn2-python3-3.9.6-env/lib/python3.9/site-packages/nbconvert/nbconvertapp.py", line 412, in export_single_notebook
    output, resources = self.exporter.from_filename(notebook_filename, resources=resources)
  File "/nix/store/nf8h3gafpdgk98d823841x054v6zmdn2-python3-3.9.6-env/lib/python3.9/site-packages/nbconvert/exporters/exporter.py", line 181, in from_filename
    return self.from_file(f, resources=resources, **kw)
  File "/nix/store/nf8h3gafpdgk98d823841x054v6zmdn2-python3-3.9.6-env/lib/python3.9/site-packages/nbconvert/exporters/exporter.py", line 199, in from_file
    return self.from_notebook_node(nbformat.read(file_stream, as_version=4), resources=resources, **kw)
  File "/nix/store/nf8h3gafpdgk98d823841x054v6zmdn2-python3-3.9.6-env/lib/python3.9/site-packages/nbconvert/exporters/notebook.py", line 32, in from_notebook_node
    nb_copy, resources = super().from_notebook_node(nb, resources, **kw)
  File "/nix/store/nf8h3gafpdgk98d823841x054v6zmdn2-python3-3.9.6-env/lib/python3.9/site-packages/nbconvert/exporters/exporter.py", line 143, in from_notebook_node
    nb_copy, resources = self._preprocess(nb_copy, resources)
  File "/nix/store/nf8h3gafpdgk98d823841x054v6zmdn2-python3-3.9.6-env/lib/python3.9/site-packages/nbconvert/exporters/exporter.py", line 318, in _preprocess
    nbc, resc = preprocessor(nbc, resc)
  File "/nix/store/nf8h3gafpdgk98d823841x054v6zmdn2-python3-3.9.6-env/lib/python3.9/site-packages/nbconvert/preprocessors/base.py", line 47, in __call__
    return self.preprocess(nb, resources)
  File "/nix/store/nf8h3gafpdgk98d823841x054v6zmdn2-python3-3.9.6-env/lib/python3.9/site-packages/nbconvert/preprocessors/execute.py", line 84, in preprocess
    self.preprocess_cell(cell, resources, index)
  File "/nix/store/nf8h3gafpdgk98d823841x054v6zmdn2-python3-3.9.6-env/lib/python3.9/site-packages/nbconvert/preprocessors/execute.py", line 105, in preprocess_cell
    cell = self.execute_cell(cell, index, store_history=True)
  File "/nix/store/nf8h3gafpdgk98d823841x054v6zmdn2-python3-3.9.6-env/lib/python3.9/site-packages/nbclient/util.py", line 78, in wrapped
    return just_run(coro(*args, **kwargs))
  File "/nix/store/nf8h3gafpdgk98d823841x054v6zmdn2-python3-3.9.6-env/lib/python3.9/site-packages/nbclient/util.py", line 57, in just_run
    return loop.run_until_complete(coro)
  File "/nix/store/97w52ckcjnfiz89h3lh7zf1kysgfm2s8-python3-3.9.6/lib/python3.9/asyncio/base_events.py", line 642, in run_until_complete
    return future.result()
  File "/nix/store/nf8h3gafpdgk98d823841x054v6zmdn2-python3-3.9.6-env/lib/python3.9/site-packages/nbclient/client.py", line 862, in async_execute_cell
    self._check_raise_for_error(cell, exec_reply)
  File "/nix/store/nf8h3gafpdgk98d823841x054v6zmdn2-python3-3.9.6-env/lib/python3.9/site-packages/nbclient/client.py", line 765, in _check_raise_for_error
    raise CellExecutionError.from_cell_and_msg(cell, exec_reply_content)
nbclient.exceptions.CellExecutionError: An error occurred while executing the following cell:
------------------
foo
------------------


<Error>: 


$ echo $?
1
```

Without this PR, the exit code is 0, and the `nbclient` exception is not thrown. I haven't done many further tests.