### PR TITLE
Add Windows support

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,8 @@
+
+-- The test runner needs package environment files to supply IHaskell packages,
+-- so make sure they are always generated.
+write-ghc-environment-files: always
+
 packages: .
           ./ipython-kernel
           ./ghc-parser

--- a/ihaskell-display/ihaskell-widgets/ihaskell-widgets.cabal
+++ b/ihaskell-display/ihaskell-widgets/ihaskell-widgets.cabal
@@ -135,8 +135,10 @@ library
                      , vinyl >= 0.5
                      , vector -any
                      , scientific -any
-                     , unix -any
                      , ihaskell >= 0.6.4.1
+
+  if !os(windows)
+    build-depends: unix -any
 
   -- Directories containing source files.
   hs-source-dirs:      src

--- a/ihaskell-display/ihaskell-widgets/src/IHaskell/Display/Widgets/Types.hs
+++ b/ihaskell-display/ihaskell-widgets/src/IHaskell/Display/Widgets/Types.hs
@@ -63,7 +63,11 @@ import           Data.String
 import           Data.Text (Text, pack)
 import           Data.Typeable (Typeable, TypeRep, typeOf, typeRep, Proxy(..))
 import           System.IO.Error
+#ifdef mingw32_HOST_OS
+import           IHaskell.Windows.IO (suppressStdin)
+#else
 import           System.Posix.IO
+#endif
 import           Text.Printf (printf)
 import           GHC.Exts (Constraint)
 import           GHC.TypeLits
@@ -891,6 +895,11 @@ noStdin action =
       handler e = when (ioeGetErrorType e == InvalidArgument)
                     (error "Widgets cannot do console input, sorry :)")
   in Ex.handle handler $ do
+#ifdef mingw32_HOST_OS
+    restore <- suppressStdin
+    void action
+    restore
+#else
 #if MIN_VERSION_unix(2,8,0)
     nullFd <- openFd "/dev/null" WriteOnly defaultFileFlags
 #else
@@ -901,6 +910,7 @@ noStdin action =
     closeFd nullFd
     void action
     void $ dupTo oldStdin stdInput
+#endif
 
 -- | Common function for the different trigger events
 triggerEvent :: forall f w. (FieldType f ~ IO (), RElemOf f (WidgetFields w)) => IPythonWidget w -> IO ()

--- a/ihaskell.cabal
+++ b/ihaskell.cabal
@@ -81,7 +81,6 @@ library
                        text                  ,
                        time                  ,
                        transformers          ,
-                       unix                  ,
                        aeson                 >=1.0,
                        base64-bytestring     >=1.0,
                        cmdargs               >=0.10,
@@ -123,6 +122,7 @@ library
   other-modules:
                    StringUtils
 
+
   if flag(use-hlint)
     exposed-modules: IHaskell.Eval.Lint
     build-depends: hlint >=1.9
@@ -130,6 +130,12 @@ library
 
   if flag(use-hlint) && impl (ghc < 8.10)
     build-depends: haskell-src-exts     >=1.18
+
+  if os(windows)
+    exposed-modules:
+      IHaskell.Windows.IO
+  else
+    build-depends: unix
 
 executable ihaskell
   -- .hs or .lhs file containing the Main module.
@@ -156,12 +162,14 @@ executable ihaskell
                        transformers         ,
                        ghc                  ,
                        process              ,
-                       unix                 ,
                        aeson                ,
                        ihaskell             ,
                        ipython-kernel       ,
                        strict               ,
                        unordered-containers
+
+  if !os(windows)
+    build-depends: unix
 
 Test-Suite hspec
     Type: exitcode-stdio-1.0
@@ -186,6 +194,7 @@ Test-Suite hspec
         ghc-paths,
         transformers,
         directory,
+        filepath,
         text,
         ihaskell,
         hspec,

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -18,7 +18,12 @@ import           System.Exit (exitSuccess, ExitCode)
 import           Control.Exception (try)
 import           System.Environment (getArgs)
 import           System.Environment (setEnv)
+#ifdef mingw32_HOST_OS
+import           GHC.ConsoleHandler
+import           System.Exit (exitWith, ExitCode(..))
+#else
 import           System.Posix.Signals
+#endif
 import qualified Data.Map as Map
 import           Data.List (break, last)
 import           Data.Version (showVersion)
@@ -230,8 +235,17 @@ runKernel kOpts profileSrc = do
 
   where
     ignoreCtrlC =
+#ifdef mingw32_HOST_OS
+      installHandler $ Catch $ \event ->
+        when (event == ControlC) $ do
+          putStrLn "Press Ctrl-C again to quit kernel."
+          void $ installHandler $ Catch $ \event' ->
+            when (event' == ControlC) $
+              exitWith (ExitFailure 130) -- 128 + SIGINT
+#else
       installHandler keyboardSignal (CatchOnce $ putStrLn "Press Ctrl-C again to quit kernel.")
         Nothing
+#endif
 
     isCommMessage req = mhMsgType (header req) `elem` [CommDataMessage, CommCloseMessage]
 

--- a/src/IHaskell/Eval/Completion.hs
+++ b/src/IHaskell/Eval/Completion.hs
@@ -289,7 +289,12 @@ getHome = do
   return $
     case homeEither of
       Left _     -> "~"
-      Right home -> home
+
+      Right home ->
+#ifdef mingw32_HOST_OS
+        map (\c -> if c == '\\' then '/' else c)
+#endif
+          home
 
 dirExpand :: String -> IO String
 dirExpand str = do
@@ -315,6 +320,19 @@ completePathWithExtensions extns line =
       where
         correctEnding ext = ext `isSuffixOf` str
 
+-- | Like 'completeFilename', but avoids duplicating backslashes in paths on
+-- Windows.
+platformCompleteFilename :: MonadIO m => CompletionFunc m
+#ifdef mingw32_HOST_OS
+platformCompleteFilename
+  -- Use 'Nothing' as the escape character on Windows,
+  -- to avoid getting paths like C:\\foo\\bar (i.e. the string "C:\\\\foo\\\\bar").
+  = completeQuotedWord Nothing "\"'" listFiles
+  $ completeWord Nothing ("\"'" ++ filenameWordBreakChars) listFiles
+#else
+platformCompleteFilename = completeFilename
+#endif
+
 completePathFilter :: (String -> Bool)      -- ^ File filter: test whether to include this file.
                    -> (String -> Bool)      -- ^ Directory filter: test whether to include this directory.
                    -> String               -- ^ Line contents to the left of the cursor.
@@ -323,7 +341,7 @@ completePathFilter :: (String -> Bool)      -- ^ File filter: test whether to in
 completePathFilter includeFile includeDirectory left right = GhcMonad.liftIO $ do
   -- Get the completions from Haskeline.  It has a bit of a strange API.
   expanded <- dirExpand left
-  completions <- map replacement <$> snd <$> completeFilename (reverse expanded, right)
+  completions <- map replacement <$> snd <$> platformCompleteFilename (reverse expanded, right)
 
   -- Split up into files and directories. Filter out ones we don't want.
   areDirs <- mapM doesDirectoryExist completions

--- a/src/IHaskell/Eval/Evaluate.hs
+++ b/src/IHaskell/Eval/Evaluate.hs
@@ -29,7 +29,9 @@ import           Data.Char as Char
 import           Data.Dynamic
 import qualified Data.Binary as Binary
 import           System.Directory
+#ifndef mingw32_HOST_OS
 import           System.Posix.IO (fdToHandle)
+#endif
 import           System.IO (hGetChar, hSetEncoding, utf8)
 import           System.Random (getStdGen, randomRs)
 import           System.Process
@@ -171,7 +173,11 @@ requiredGlobalImports :: [String]
 requiredGlobalImports =
   [ "import qualified Prelude as IHaskellPrelude"
   , "import qualified System.Directory as IHaskellDirectory"
+#ifdef mingw32_HOST_OS
+  , "import qualified System.Process as IHaskellProcess"
+#else
   , "import qualified System.Posix.IO as IHaskellIO"
+#endif
   , "import qualified System.IO as IHaskellSysIO"
   , "import qualified Language.Haskell.TH as IHaskellTH"
   ]
@@ -182,6 +188,9 @@ ihaskellGlobalImports =
   , "import qualified IHaskell.Display"
   , "import qualified IHaskell.IPython.Stdin"
   , "import qualified IHaskell.Eval.Widgets"
+#ifdef mingw32_HOST_OS
+  , "import qualified IHaskell.Windows.IO as IHaskellIO"
+#endif
   ]
 
 hiddenPackageNames :: Set.Set String
@@ -216,8 +225,13 @@ interpret libdir allowedStdin needsSupportLibraries action = runGhc (Just libdir
   hasSupportLibraries <- initializeImports needsSupportLibraries
 
   -- Close stdin so it can't be used. Otherwise it'll block the kernel forever.
-  dir <- liftIO getIHaskellDir
-  let cmd = printf "IHaskell.IPython.Stdin.fixStdin \"%s\"" dir
+  dir0 <- liftIO getIHaskellDir
+  let
+    -- Escape backslashes to avoid producing invalid strings, e.g. when
+    -- dealing with a Windows-style path "C:\blah\stuff": need to escape
+    -- the slashes for \b and \s.
+    dir = replace "\\" "\\\\" dir0
+    cmd = printf "IHaskell.IPython.Stdin.fixStdin \"%s\"" dir
   when (allowedStdin && hasSupportLibraries) $ void $
     execStmt cmd execOptions
 
@@ -829,9 +843,13 @@ evalCommand publish (Directive ShellCmd cmd) state = wrapExecution state $
           liftIO $ setCurrentDirectory directory
 
           -- Set the directory for user code.
-          let cmd1 = printf "IHaskellDirectory.setCurrentDirectory \"%s\"" $
-                replace " " "\\ " $
-                  replace "\"" "\\\"" directory
+          let
+            -- Escape backslashes and spaces to handle Windows-style filepaths.
+            dir' = replace " " "\\ "
+                $ replace "\"" "\\\""
+                $ replace "\\" "\\\\" directory
+            cmd1 = printf "IHaskellDirectory.setCurrentDirectory \"%s\"" dir'
+
           _ <- execStmt cmd1 execOptions
           return mempty
         else return $ displayError $ printf "No such directory: '%s'" directory
@@ -1359,6 +1377,17 @@ capturedEval output stmt = do
   -- using the right names in the terminal.
   gen <- liftIO getStdGen
   let
+      goStmt :: String -> Ghc ExecResult
+      goStmt s = execStmt s execOptions
+
+      runWithResult (CapturedStmt str) = goStmt str
+      runWithResult (CapturedIO io) = do
+        stat <- gcatch (liftIO io >> return NoException) (return . AnyException)
+        return $
+          case stat of
+            NoException    -> ExecComplete (Right []) 0
+            AnyException e -> ExecComplete (Left e)   0
+
       -- Variable names generation.
       rand = take 20 $ randomRs ('0', '9') gen
       var name = name ++ rand
@@ -1367,16 +1396,47 @@ capturedEval output stmt = do
       readVariable = var "file_read_var_"
       writeVariable = var "file_write_var_"
 
+      -- Variable used to store true `it` value.
+      itVariable = var "it_var_"
+
+      voidpf str = printf $ str ++ " IHaskellPrelude.>> IHaskellPrelude.return ()"
+
+#ifdef mingw32_HOST_OS
+  let -- Variables used to restore stdout/stderr
+      restoreVariableStdout = var "restore_stdout_var_"
+      restoreVariableStderr = var "restore_stderr_var_"
+      initStmts =
+        [ printf "let %s = it" itVariable
+        , printf "(%s, %s) <- IHaskellProcess.createPipe" readVariable writeVariable
+
+        -- Handle redirection
+        , printf "%s <- IHaskellIO.redirectHandle %s IHaskellSysIO.stdout" restoreVariableStdout writeVariable
+        , printf "%s <- IHaskellIO.redirectHandle %s IHaskellSysIO.stderr" restoreVariableStderr writeVariable
+
+        , voidpf "IHaskellSysIO.hSetBuffering IHaskellSysIO.stdout IHaskellSysIO.NoBuffering"
+        , voidpf "IHaskellSysIO.hSetBuffering IHaskellSysIO.stderr IHaskellSysIO.NoBuffering"
+
+        -- Important: set text encoding to UTF-8
+        , voidpf "IHaskellSysIO.hSetEncoding IHaskellSysIO.stdout IHaskellSysIO.utf8"
+        , voidpf "IHaskellSysIO.hSetEncoding IHaskellSysIO.stderr IHaskellSysIO.utf8"
+        , printf "let it = %s" itVariable
+        ]
+      postStmts =
+        [ printf "let %s = it" itVariable
+        , voidpf "IHaskellSysIO.hFlush IHaskellSysIO.stdout"
+        , voidpf "IHaskellSysIO.hFlush IHaskellSysIO.stderr"
+        , voidpf "%s" restoreVariableStdout
+        , voidpf "%s" restoreVariableStderr
+        , voidpf "IHaskellSysIO.hClose %s" writeVariable
+        , printf "let it = %s" itVariable
+        ]
+#else
+  let
       -- Variable where to store old stdout.
       oldVariableStdout = var "old_var_stdout_"
 
       -- Variable where to store old stderr.
       oldVariableStderr = var "old_var_stderr_"
-
-      -- Variable used to store true `it` value.
-      itVariable = var "it_var_"
-
-      voidpf str = printf $ str ++ " IHaskellPrelude.>> IHaskellPrelude.return ()"
 
       -- Statements run before the thing we're evaluating.
       initStmts =
@@ -1401,17 +1461,7 @@ capturedEval output stmt = do
         , voidpf "IHaskellIO.closeFd %s" writeVariable
         , printf "let it = %s" itVariable
         ]
-
-      goStmt :: String -> Ghc ExecResult
-      goStmt s = execStmt s execOptions
-
-      runWithResult (CapturedStmt str) = goStmt str
-      runWithResult (CapturedIO io) = do
-        stat <- gcatch (liftIO io >> return NoException) (return . AnyException)
-        return $
-          case stat of
-            NoException    -> ExecComplete (Right []) 0
-            AnyException e -> ExecComplete (Left e)   0
+#endif
 
   -- Initialize evaluation context.
   forM_ initStmts goStmt
@@ -1420,10 +1470,16 @@ capturedEval output stmt = do
   dyn <- dynCompileExpr readVariable
   pipe <- case fromDynamic dyn of
             Nothing -> error "Evaluate: Bad pipe"
+#ifdef mingw32_HOST_OS
+            Just hdl -> liftIO $ do
+                hSetEncoding hdl utf8
+                return hdl
+#else
             Just fd -> liftIO $ do
                 hdl <- fdToHandle fd
                 hSetEncoding hdl utf8
                 return hdl
+#endif
 
   -- Keep track of whether execution has completed.
   completed <- liftIO $ newMVar False

--- a/src/IHaskell/Eval/Evaluate.hs
+++ b/src/IHaskell/Eval/Evaluate.hs
@@ -227,23 +227,21 @@ interpret libdir allowedStdin needsSupportLibraries action = runGhc (Just libdir
   action hasSupportLibraries
 
 #if MIN_VERSION_ghc(9,4,0)
-packageIdString' :: Logger -> DynFlags -> HscEnv -> UnitInfo -> IO String
-packageIdString' logger dflags hsc_env pkg_cfg = do
-    (_, unitState, _, _) <- initUnits logger dflags Nothing (hsc_all_home_unit_ids hsc_env)
+packageIdString' :: UnitState -> UnitInfo -> String
+packageIdString' unitState pkg_cfg =
     case (lookupUnit unitState $ mkUnit pkg_cfg) of
-      Nothing -> pure "(unknown)"
+      Nothing -> "(unknown)"
       Just cfg -> let
         PackageName name = unitPackageName cfg
-        in pure $ unpackFS name
+        in unpackFS name
 #elif MIN_VERSION_ghc(9,2,0)
-packageIdString' :: Logger -> DynFlags -> UnitInfo -> IO String
-packageIdString' logger dflags pkg_cfg = do
-    (_, unitState, _, _) <- initUnits logger dflags Nothing
+packageIdString' :: UnitState -> UnitInfo -> String
+packageIdString' unitState pkg_cfg =
     case (lookupUnit unitState $ mkUnit pkg_cfg) of
-      Nothing -> pure "(unknown)"
+      Nothing -> "(unknown)"
       Just cfg -> let
         PackageName name = unitPackageName cfg
-        in pure $ unpackFS name
+        in unpackFS name
 #elif MIN_VERSION_ghc(9,0,0)
 packageIdString' :: DynFlags -> UnitInfo -> String
 packageIdString' dflags pkg_cfg =
@@ -263,15 +261,15 @@ packageIdString' dflags pkg_cfg =
 #endif
 
 #if MIN_VERSION_ghc(9,4,0)
-getPackageConfigs :: Logger -> DynFlags -> HscEnv -> IO [GenUnitInfo UnitId]
+getPackageConfigs :: Logger -> DynFlags -> HscEnv -> IO ([GenUnitInfo UnitId], UnitState)
 getPackageConfigs logger dflags hsc_env = do
-    (pkgDb, _, _, _) <- initUnits logger dflags Nothing (hsc_all_home_unit_ids hsc_env)
-    pure $ foldMap unitDatabaseUnits pkgDb
+    (pkgDb, unitState, _, _) <- initUnits logger dflags Nothing (hsc_all_home_unit_ids hsc_env)
+    pure (foldMap unitDatabaseUnits pkgDb, unitState)
 #elif MIN_VERSION_ghc(9,2,0)
-getPackageConfigs :: Logger -> DynFlags -> IO [GenUnitInfo UnitId]
+getPackageConfigs :: Logger -> DynFlags -> IO ([GenUnitInfo UnitId], UnitState)
 getPackageConfigs logger dflags = do
-    (pkgDb, _, _, _) <- initUnits logger dflags Nothing
-    pure $ foldMap unitDatabaseUnits pkgDb
+    (pkgDb, unitState, _, _) <- initUnits logger dflags Nothing
+    pure (foldMap unitDatabaseUnits pkgDb, unitState)
 #elif MIN_VERSION_ghc(9,0,0)
 getPackageConfigs :: DynFlags -> [GenUnitInfo UnitId]
 getPackageConfigs dflags =
@@ -302,19 +300,21 @@ initializeImports importSupportLibraries = do
   (dflgs, _) <- liftIO $ initPackages dflags
 #endif
 
+  -- NB: make sure to only call 'initUnits' once, as it is quite expensive
+  -- especially when there are many dependencies.
 #if MIN_VERSION_ghc(9,4,0)
   logger <- getLogger
   hsc_env <- getSession
-  db <- liftIO $ getPackageConfigs logger dflgs hsc_env
-  packageNames <- liftIO $ mapM (packageIdString' logger dflgs hsc_env) db
-  let hiddenPackages = Set.intersection hiddenPackageNames (Set.fromList packageNames)
+  (db, unitState) <- liftIO $ getPackageConfigs logger dflgs hsc_env
+  let packageNames = map (packageIdString' unitState) db
+      hiddenPackages = Set.intersection hiddenPackageNames (Set.fromList packageNames)
       hiddenFlags = fmap HidePackage $ Set.toList hiddenPackages
       initStr = "ihaskell-"
 #elif MIN_VERSION_ghc(9,2,0)
   logger <- getLogger
-  db <- liftIO $ getPackageConfigs logger dflgs
-  packageNames <- liftIO $ mapM (packageIdString' logger dflgs) db
-  let hiddenPackages = Set.intersection hiddenPackageNames (Set.fromList packageNames)
+  (db, unitState) <- liftIO $ getPackageConfigs logger dflgs
+  let packageNames = map (packageIdString' unitState) db
+      hiddenPackages = Set.intersection hiddenPackageNames (Set.fromList packageNames)
       hiddenFlags = fmap HidePackage $ Set.toList hiddenPackages
       initStr = "ihaskell-"
 #else

--- a/src/IHaskell/IPython/Stdin.hs
+++ b/src/IHaskell/IPython/Stdin.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE NoImplicitPrelude, OverloadedStrings, DoAndIfThenElse #-}
+{-# LANGUAGE NoImplicitPrelude, OverloadedStrings, DoAndIfThenElse, CPP #-}
 
 -- | This module provides a way in which the Haskell standard input may be forwarded to the IPython
 -- frontend and thus allows the notebook to use the standard input.
@@ -31,7 +31,11 @@ import           Control.Concurrent
 import           GHC.IO.Handle
 import           GHC.IO.Handle.Types
 import           System.FilePath ((</>))
+#ifdef mingw32_HOST_OS
+import           System.Process (createPipe)
+#else
 import           System.Posix.IO
+#endif
 import           System.IO.Unsafe
 
 import           IHaskell.IPython.Types
@@ -57,9 +61,13 @@ fixStdin dir = do
 stdinOnce :: String -> IO ()
 stdinOnce dir = do
   -- Create a pipe using and turn it into handles.
+#ifdef mingw32_HOST_OS
+  (newStdin, stdinInput) <- createPipe
+#else
   (readEnd, writeEnd) <- createPipe
   newStdin <- fdToHandle readEnd
   stdinInput <- fdToHandle writeEnd
+#endif
   hSetBuffering newStdin NoBuffering
   hSetBuffering stdinInput NoBuffering
 

--- a/src/IHaskell/Windows/IO.hs
+++ b/src/IHaskell/Windows/IO.hs
@@ -1,0 +1,93 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+-- | Functionality for redirecting handles on Windows, corresponding to
+-- Posix functionality in System.Posix.IO.
+--
+-- The core problem this solves is that GHC API's dynamic session has its own
+-- copy of stdout (from the dynamically loaded base), which is a different
+-- 'Handle' object than anything in the static code (even if we try to redirect
+-- statically).
+--
+-- We need to redirect at the OS file descriptor level on Windows (like in the Posix
+-- implementation), but 'hDuplicateTo' won't work because the pipe handle and
+-- stdout have incompatible types, causing errors like:
+--
+-- > hDuplicateTo: illegal operation (handles are incompatible)
+--
+-- To solve this we use Windows CRT file descriptors, which provide appropriate
+-- functionality to replicate the Posix setup.
+module IHaskell.Windows.IO
+  ( redirectHandle
+  , suppressStdin
+  ) where
+
+-- base
+import Control.Monad
+  ( void, when )
+import Data.Typeable
+  ( cast )
+import Foreign.C.Types
+  ( CInt(..) )
+import GHC.IO.FD
+  ( FD(..) )
+import GHC.IO.Handle.Types
+  ( Handle(..), Handle__(..) )
+import System.IO
+  ( openFile, hClose, IOMode(..), stdin )
+
+-- stm
+import Control.Concurrent.MVar
+  ( readMVar )
+
+--------------------------------------------------------------------------------
+
+-- Windows-specific FFI imports for CRT file descriptors
+foreign import ccall unsafe "_dup"   c_dup   :: CInt -> IO CInt
+foreign import ccall unsafe "_dup2"  c_dup2  :: CInt -> CInt -> IO CInt
+foreign import ccall unsafe "_close" c_close :: CInt -> IO CInt
+
+-- | Redirect @dst@ to write through @src@ at the OS file-descriptor level
+-- using Windows @_dup@\/@_dup2@ operations.
+--
+-- Returns an action that restores @dst@.
+--
+-- This operates on CRT file descriptors (not Haskell Handle state), to
+-- ensure that both Haskell and C IO operations get properly rerouted.
+redirectHandle :: Handle -> Handle -> IO (IO ())
+redirectHandle src dst = do
+  srcFd <- handleFd src
+  dstFd <- handleFd dst
+  savedFd <- c_dup dstFd
+  when (savedFd == -1) $
+    ioError (userError "redirectHandle: _dup failed")
+  r <- c_dup2 srcFd dstFd
+  when (r == -1) $ do
+    void $ c_close savedFd
+    ioError (userError "redirectHandle: _dup2 failed")
+  return $ do
+    r2 <- c_dup2 savedFd dstFd
+    void $ c_close savedFd
+    when (r2 == -1) $
+      ioError (userError "redirectHandle: restore _dup2 failed")
+
+-- | Redirect 'stdin' to @NUL@ (write-only), causing reads to fail with an
+-- @InvalidArgument@ error.
+--
+-- Returns an action that restores 'stdin'.
+suppressStdin :: IO (IO ())
+suppressStdin = do
+  nullHandle <- openFile "NUL" WriteMode
+  restore <- redirectHandle nullHandle stdin
+  hClose nullHandle
+  return restore
+
+handleFd :: Handle -> IO CInt
+handleFd h = do
+  Handle__ { haDevice = dev } <- getHandleState h
+  case cast dev of
+    Just fd -> return (fdFD fd)
+    Nothing -> ioError (userError "handleFd: handle has no CRT file descriptor")
+
+getHandleState :: Handle -> IO Handle__
+getHandleState (FileHandle _fp handleVar) = readMVar handleVar
+getHandleState (DuplexHandle _fp _readSideVar writeSideVar) = readMVar writeSideVar

--- a/src/tests/Hspec.hs
+++ b/src/tests/Hspec.hs
@@ -2,9 +2,11 @@ module Main where
 
 import           Prelude
 import           Control.Monad (when)
-import           System.Directory (doesPathExist, getCurrentDirectory)
+import           Data.List (isPrefixOf)
+import           Data.Maybe (fromMaybe, listToMaybe)
+import           System.Directory (doesPathExist, getCurrentDirectory, listDirectory)
 import           System.Environment (lookupEnv, setEnv)
-import           Data.Maybe (fromMaybe)
+import           System.FilePath ((</>))
 
 import           Test.Hspec
 
@@ -20,6 +22,12 @@ main = do
   when packageConfInPlaceExists $ do
     ghcPackagePath <- fromMaybe "" <$> lookupEnv "GHC_PACKAGE_PATH"
     setEnv "GHC_PACKAGE_PATH" $ currentDir ++ "/dist/package.conf.inplace/" ++ ":" ++ ghcPackagePath
+  -- Set GHC_ENVIRONMENT so that runGhc sessions (used by completion tests)
+  -- can find local packages, regardless of the working directory.
+  envFiles <- listDirectory currentDir
+  case listToMaybe $ filter (".ghc.environment." `isPrefixOf`) envFiles of
+    Just f  -> setEnv "GHC_ENVIRONMENT" (currentDir </> f)
+    Nothing -> return ()
   hspec $ do
     testParser
     testEval

--- a/src/tests/IHaskell/Test/Completion.hs
+++ b/src/tests/IHaskell/Test/Completion.hs
@@ -14,16 +14,7 @@ import           Control.Monad.IO.Class (liftIO)
 import           System.Environment (setEnv)
 import           System.Directory (setCurrentDirectory, getCurrentDirectory)
 
-#if MIN_VERSION_ghc(9,6,0)
-import           GHC (getSessionDynFlags, setSessionDynFlags, DynFlags(..), GhcLink(..), setContext,
-                      parseImportDecl, interpreterBackend, Backend(..), InteractiveImport(..))
-#elif MIN_VERSION_ghc(9,2,0)
-import           GHC (getSessionDynFlags, setSessionDynFlags, DynFlags(..), GhcLink(..), setContext,
-                      parseImportDecl, Backend(..), InteractiveImport(..))
-#else
-import           GHC (getSessionDynFlags, setSessionDynFlags, DynFlags(..), GhcLink(..), setContext,
-                      parseImportDecl, HscTarget(..), InteractiveImport(..))
-#endif
+import           GHC (setContext, parseImportDecl, InteractiveImport(..))
 
 import           Test.Hspec
 
@@ -31,9 +22,10 @@ import           Shelly (toTextIgnore, (</>), shelly, fromText, get_env_text, Fi
                          touchfile, withTmpDir)
 
 import           IHaskell.Eval.Evaluate (Interpreter, liftIO)
+import           IHaskell.IPython (getSandboxPackageConf)
 import           IHaskell.Eval.Completion (complete, CompletionType(..), completionType,
                                            completionTarget)
-import           IHaskell.Eval.Util (setWayDynFlag)
+import           IHaskell.Eval.Util (initGhci)
 import           IHaskell.Test.Util (replace, shouldBeAmong, ghc)
 
 -- | @readCompletePrompt "xs*ys"@ return @(xs, i)@ where i is the location of
@@ -69,15 +61,8 @@ completionHas string expected = do
 
 initCompleter :: Interpreter ()
 initCompleter = do
-  flags <- getSessionDynFlags
-#if MIN_VERSION_ghc(9,6,0)
-  _ <- setSessionDynFlags $ setWayDynFlag flags { backend = interpreterBackend, ghcLink = LinkInMemory }
-#elif MIN_VERSION_ghc(9,2,0)
-  _ <- setSessionDynFlags $ setWayDynFlag flags { backend = Interpreter, ghcLink = LinkInMemory }
-#else
-  _ <- setSessionDynFlags $ setWayDynFlag flags { hscTarget = HscInterpreted, ghcLink = LinkInMemory }
-#endif
-
+  sandboxPackages <- liftIO getSandboxPackageConf
+  initGhci sandboxPackages
   -- Import modules.
   imports <- mapM parseImportDecl
                [ "import Prelude"

--- a/src/tests/IHaskell/Test/Completion.hs
+++ b/src/tests/IHaskell/Test/Completion.hs
@@ -13,6 +13,7 @@ import qualified Data.Text as T
 import           Control.Monad.IO.Class (liftIO)
 import           System.Environment (setEnv)
 import           System.Directory (setCurrentDirectory, getCurrentDirectory)
+import           System.FilePath (addTrailingPathSeparator)
 
 import           GHC (setContext, parseImportDecl, InteractiveImport(..))
 
@@ -144,12 +145,12 @@ testCommandCompletion = describe "Completes commands" $ do
     testInDirectory ("dir" </> "file*") ["dir" </> "file2.hs", "dir" </> "file2.lhs"]
     testInDirectory ("" </> "file1*") ["" </> "file1.hs", "" </> "file1.lhs"]
     testInDirectory ("" </> "file1*") ["" </> "file1.hs", "" </> "file1.lhs"]
-    testInDirectory ("" </> "./*") ["./" </> "dir/", "./" </> "file1.hs", "./" </> "file1.lhs"]
-    testInDirectory ("" </> "./*") ["./" </> "dir/", "./" </> "file1.hs", "./" </> "file1.lhs"]
+    testInDirectory ("" </> "." </> "*") [addTrailingPathSeparator $ "." </> "dir", "." </> "file1.hs", "." </> "file1.lhs"]
+    testInDirectory ("" </> "." </> "*") [addTrailingPathSeparator $ "." </> "dir", "." </> "file1.hs", "." </> "file1.lhs"]
 
   it "provides path completions on empty shell cmds " $
     ":! cd *" `shouldHaveCompletionsInDirectory` map (T.unpack . toTextIgnore)
-                                                   [ "" </> "dir/"
+                                                   [ addTrailingPathSeparator $ "" </> "dir"
                                                    , "" </> "file1.hs"
                                                    , "" </> "file1.lhs"
                                                    ]
@@ -163,15 +164,17 @@ testCommandCompletion = describe "Completes commands" $ do
       setHomeEvent path = liftIO $ setEnv "HOME" (T.unpack $ toTextIgnore path)
 
   it "correctly interprets ~ as the environment HOME variable" $ do
-    let shouldHaveCompletions :: String -> [String] -> IO ()
+    let tildeDir = addTrailingPathSeparator $ "~" </> "dir"
+
+        shouldHaveCompletions :: String -> [String] -> IO ()
         shouldHaveCompletions string expected = do
           (_, completions) <- withHsHome $ completionEvent string
 
           expected `shouldBeAmong` completions
-    ":! cd ~/*" `shouldHaveCompletions` ["~/dir/"]
-    ":! ~/*" `shouldHaveCompletions` ["~/dir/"]
-    ":load ~/*" `shouldHaveCompletions` ["~/dir/"]
-    ":l ~/*" `shouldHaveCompletions` ["~/dir/"]
+    (":! cd ~" </> "*") `shouldHaveCompletions` [tildeDir]
+    (":! ~" </> "*") `shouldHaveCompletions` [tildeDir]
+    (":load ~" </> "*") `shouldHaveCompletions` [tildeDir]
+    (":l ~" </> "*") `shouldHaveCompletions` [tildeDir]
 
   let shouldHaveMatchingText :: String -> String -> IO ()
       shouldHaveMatchingText string expected = do

--- a/src/tests/IHaskell/Test/Eval.hs
+++ b/src/tests/IHaskell/Test/Eval.hs
@@ -9,7 +9,7 @@ import           Prelude
 import           Control.Monad (when, forM_)
 import           Data.Aeson (encode)
 import           Data.IORef (newIORef, modifyIORef, readIORef)
-import           System.Directory (getTemporaryDirectory, setCurrentDirectory)
+import           System.Directory (getTemporaryDirectory, setCurrentDirectory, getCurrentDirectory)
 
 import           Text.RawString.QQ (r)
 
@@ -17,7 +17,7 @@ import qualified GHC.Paths
 
 import           Test.Hspec
 
-import           IHaskell.Eval.Evaluate (interpret, evaluate)
+import           IHaskell.Eval.Evaluate (interpret, evaluate, liftIO)
 import           IHaskell.Test.Util (strip)
 import           IHaskell.Types (Display(..), DisplayData(..), EvaluationResult(..), KernelState(..),
                                  LintStatus(..), MimeType(..), defaultKernelState, extractPlain)
@@ -33,11 +33,14 @@ eval string = do
             modifyIORef outputAccum (outs :)
             modifyIORef pagerAccum (page :)
       noWidgetHandling s _ = return s
-
-  getTemporaryDirectory >>= setCurrentDirectory
   let state = defaultKernelState { getLintStatus = LintOff }
-  _ <- interpret GHC.Paths.libdir False False $ const $
-        IHaskell.Eval.Evaluate.evaluate state string publish noWidgetHandling
+
+  liftIO $ getTemporaryDirectory >>= setCurrentDirectory
+  _ <- interpret GHC.Paths.libdir False False $ \hasSupportLibraries -> do
+        IHaskell.Eval.Evaluate.evaluate
+          (state { supportLibrariesAvailable = hasSupportLibraries })
+          string publish noWidgetHandling
+
   out <- readIORef outputAccum
   pagerout <- readIORef pagerAccum
   return (reverse out, unlines . map extractPlain . reverse $ pagerout)

--- a/src/tests/IHaskell/Test/Eval.hs
+++ b/src/tests/IHaskell/Test/Eval.hs
@@ -9,6 +9,7 @@ import           Prelude
 import           Control.Monad (when, forM_)
 import           Data.Aeson (encode)
 import           Data.IORef (newIORef, modifyIORef, readIORef)
+import qualified Data.Text as Text
 import           System.Directory (getTemporaryDirectory, setCurrentDirectory, getCurrentDirectory)
 
 import           Text.RawString.QQ (r)
@@ -170,28 +171,18 @@ testEval =
       ":k Maybe" `becomes` ["Maybe :: * -> *"]
 
     it "evaluates :in directive" $ do
-#if MIN_VERSION_ghc(9,10,0)
-      displayDatasBecome ":in String" [
-        ManyDisplay [Display [
-                        DisplayData PlainText "type String :: *\ntype String = [Char]\n  \t-- Defined in \8216GHC.Internal.Base\8217"
-                        , DisplayData MimeHtml "<div class=\"code CodeMirror cm-s-jupyter cm-s-ipython\"><span class=\"cm-keyword\">type</span><span class=\"cm-space\"> </span><span class=\"cm-variable-2\">String</span><span class=\"cm-space\"> </span><span class=\"cm-atom\">::</span><span class=\"cm-space\"> </span><span class=\"cm-atom\">*</span><span class=\"cm-space\"><br /></span>\n<span class=\"cm-keyword\">type</span><span class=\"cm-space\"> </span><span class=\"cm-variable-2\">String</span><span class=\"cm-space\"> </span><span class=\"cm-atom\">=</span><span class=\"cm-space\"> </span><span class=\"cm-atom\">[</span><span class=\"cm-variable-2\">Char</span><span class=\"cm-atom\">]</span><span class=\"cm-space\"><br />  \t</span><span class=\"cm-comment\">-- Defined in \8216GHC.Internal.Base\8217</span><span class=\"cm-space\"><br /></span></div>"
-                        ]]
-        ]
-#elif MIN_VERSION_ghc(8,10,0)
-      displayDatasBecome ":in String" [
-        ManyDisplay [Display [
-                        DisplayData PlainText "type String :: *\ntype String = [Char]\n  \t-- Defined in \8216GHC.Base\8217"
-                        , DisplayData MimeHtml "<div class=\"code CodeMirror cm-s-jupyter cm-s-ipython\"><span class=\"cm-keyword\">type</span><span class=\"cm-space\"> </span><span class=\"cm-variable-2\">String</span><span class=\"cm-space\"> </span><span class=\"cm-atom\">::</span><span class=\"cm-space\"> </span><span class=\"cm-atom\">*</span><span class=\"cm-space\"><br /></span>\n<span class=\"cm-keyword\">type</span><span class=\"cm-space\"> </span><span class=\"cm-variable-2\">String</span><span class=\"cm-space\"> </span><span class=\"cm-atom\">=</span><span class=\"cm-space\"> </span><span class=\"cm-atom\">[</span><span class=\"cm-variable-2\">Char</span><span class=\"cm-atom\">]</span><span class=\"cm-space\"><br />  \t</span><span class=\"cm-comment\">-- Defined in \8216GHC.Base\8217</span><span class=\"cm-space\"><br /></span></div>"
-                        ]]
-        ]
-#else
-      displayDatasBecome ":in String" [
-        ManyDisplay [Display [
-                        DisplayData PlainText "type String = [Char] \t-- Defined in \8216GHC.Base\8217"
-                        , DisplayData MimeHtml "<div class=\"code CodeMirror cm-s-jupyter cm-s-ipython\"><span class=\"cm-keyword\">type</span><span class=\"cm-space\"> </span><span class=\"cm-variable-2\">String</span><span class=\"cm-space\"> </span><span class=\"cm-atom\">=</span><span class=\"cm-space\"> </span><span class=\"cm-atom\">[</span><span class=\"cm-variable-2\">Char</span><span class=\"cm-atom\">]</span><span class=\"cm-space\"> \t</span><span class=\"cm-comment\">-- Defined in \8216GHC.Base\8217</span><span class=\"cm-space\"><br /></span></div>"
-                        ]]
-        ]
-#endif
+      (displays, _) <- eval ":in String"
+      case displays of
+        [ManyDisplay [Display [DisplayData PlainText plain, DisplayData MimeHtml html]]] -> do
+          -- The type definition is stable; the module name and whether quotation
+          -- marks use unicode vary across GHC versions and platforms, so don't
+          -- check everything.
+          Text.unpack plain `shouldContain` "type String = [Char]"
+          Text.unpack html  `shouldContain` "<span class=\"cm-keyword\">type</span>"
+          Text.unpack html  `shouldContain` "<span class=\"cm-variable-2\">String</span>"
+          Text.unpack html  `shouldContain` "<span class=\"cm-variable-2\">Char</span>"
+        _ -> expectationFailure $ "Unexpected display structure for :in String: "
+                                    ++ show (encode displays)
 
     it "captures stderr" $ do
       [r|

--- a/src/tests/IHaskell/Test/Eval.hs
+++ b/src/tests/IHaskell/Test/Eval.hs
@@ -58,9 +58,16 @@ becomes string expected = evaluationComparing comparison string
         expectationFailure $ "Expected result to have " ++ show (length expected)
                                                         ++ " results. Got " ++ show (encode results)
 
-      forM_ (zip results expected) $ \(ManyDisplay [Display result], expect) -> case extractPlain result of
-        ""  -> expectationFailure $ "No plain-text output in " ++ show result ++ "\nExpected: " ++ expect
-        str -> str `shouldBe` expect
+      forM_ (zip results expected) $ \(result, expect) ->
+        case getPlain result of
+          "" -> expectationFailure $ "No plain-text output in " ++ show result ++ "\nExpected: " ++ expect
+          str -> str `shouldBe` expect
+
+    getPlain :: Display -> String
+    getPlain (Display datas)
+      = filter (/= '\r') -- normalise Windows line endings
+      $ extractPlain datas
+    getPlain (ManyDisplay disps) = concatMap getPlain disps
 
 evaluationComparing :: (([Display], String) -> IO b) -> String -> IO b
 evaluationComparing comparison string = do


### PR DESCRIPTION
This PR adds Windows support to IHaskell. I have been testing it locally on [a presentation involving a lot of plotting](https://codeberg.org/sheaf/chebyshev-talk) and it's working flawlessly.

There are several preparatory commits; in particular the commit `Avoid repeatedly calling initUnits` was crucial to improve testsuite performance as the tests took ages to run without that (see commit message for details).

The main (last) commit achieves Windows support as follows:

  - It introduces the compatibility module `IHaskell.Windows.IO` which provides the necessary handle redirection functionality that is otherwise provided by the `unix` package.
 - It updates `IHaskell.Eval.Evaluate` to use this module on Windows when communicating with the GHC session.

There's also a fair amount of faffing around with Windows vs POSIX file path separators in the testsuite, to get the testsuite green on Windows.